### PR TITLE
Disable unavailable install methods and guard execution

### DIFF
--- a/tests/test_install_modal.py
+++ b/tests/test_install_modal.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import Mock
+
+from ricekit import KitApp
+from textual.widgets import OptionList
+
+from tuistore.app import InstallModal
+from tuistore.catalog import Entry
+from tuistore.installer import make
+from tuistore.platform import Env
+
+
+class Harness(KitApp):
+    def __init__(self) -> None:
+        super().__init__()
+        self.env = Env("linux", "arch", {"arch"}, tools={"cargo"})
+
+
+class InstallModalAvailabilityTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.entry = Entry("haal", "https://github.com/example/haal")
+        self.cargo = make("cargo", "cargo install haal")
+        self.binstall = make("cargo-binstall", "cargo binstall haal")
+
+    async def test_unavailable_picker_option_is_disabled(self) -> None:
+        modal = InstallModal(self.entry, self.cargo, [self.binstall])
+        app = Harness()
+
+        async with app.run_test() as pilot:
+            app.push_screen(modal)
+            await pilot.pause()
+            modal.action_alternatives()
+            await pilot.pause()
+
+            options = app.screen.query_one(OptionList)
+            self.assertFalse(options.get_option_at_index(0).disabled)
+            self.assertTrue(options.get_option_at_index(1).disabled)
+
+    async def test_enter_does_not_run_unavailable_method(self) -> None:
+        modal = InstallModal(self.entry, self.binstall, [])
+        app = Harness()
+        app.notify = Mock()
+
+        async with app.run_test() as pilot:
+            app.push_screen(modal)
+            await pilot.pause()
+            modal._install = Mock()
+
+            modal.action_run()
+
+            self.assertFalse(modal.running)
+            modal._install.assert_not_called()
+            app.notify.assert_called_once_with("needs cargo-binstall", severity="warning")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tuistore/app.py
+++ b/tuistore/app.py
@@ -225,14 +225,19 @@ class InstallModal(ModalScreen):
         opts = []
         env = self.app.env
         for i, m in enumerate([self.method] + self.alternatives):
+            # Dim text explains why a method cannot run, but styling alone does
+            # not stop Textual from highlighting and selecting the row.
+            available = m.available(env)
             row = Text()
             row.append("● " if i == 0 else "○ ",
-                       style=palette.blue if m.available(env) else palette.faint)
-            row.append(f"{m.label}  ", style=palette.text if m.available(env) else palette.dim)
+                       style=palette.blue if available else palette.faint)
+            row.append(f"{m.label}  ", style=palette.text if available else palette.dim)
             row.append(m.command, style=palette.dim)
-            if not m.available(env):
+            if not available:
                 row.append(f"  ({m.why_unavailable(env)})", style=palette.peach)
-            opts.append(Option(row, id=str(i)))
+            # Textual's native disabled state blocks both keyboard and mouse
+            # selection while preserving the unavailable method as guidance.
+            opts.append(Option(row, id=str(i), disabled=not available))
 
         def picked(idx: str | None) -> None:
             if idx is None:
@@ -249,6 +254,13 @@ class InstallModal(ModalScreen):
             self.dismiss(None)
             return
         if self.running:
+            return
+        # The selected method may predate an environment change or arrive from
+        # another caller, so the picker cannot be the only safety boundary.
+        if not self.method.available(self.app.env):
+            # Keep Enter harmless and explain exactly what the user must install
+            # instead of starting a command that is guaranteed to fail.
+            self.app.notify(self.method.why_unavailable(self.app.env), severity="warning")
             return
         self.running = True
         self.query_one("#log").add_class("on")


### PR DESCRIPTION
## Summary

- Disable unavailable methods in the install-method picker.
- Preserve unavailable methods visually so users can see missing requirements.
- Guard Enter execution when the selected method is unavailable.
- Show a warning such as `needs cargo-binstall` instead of running a predictable failure.
- Add regression tests covering picker state and execution blocking.

## Testing

- `uv run python -m unittest discover -s tests -v` — passed
- `uv run python -m compileall -q tuistore tests` — passed