### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13"]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ uv run tuistore
 uv run python -m unittest discover tests -v
 ```
 
-CI runs this on Python 3.11, 3.12, and 3.13 for every PR.
+CI runs this on Ubuntu and Windows for Python 3.11, 3.12, and 3.13 on every PR.
 
 ## fixing the install engine
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ uv tool install git+https://github.com/Gheat1/tuistore   # recommended
 pipx install git+https://github.com/Gheat1/tuistore
 ```
 
+Windows is supported in PowerShell (or Windows Terminal) too. Install any of
+the package managers and toolchains you already use — `winget`, Scoop,
+Chocolatey, `uv`, Cargo, Go, and npm are detected automatically — then run the
+same command above. Windows-specific methods are offered only on Windows.
+
 Then just run:
 
 ```sh
@@ -204,13 +209,13 @@ If you like tuistore, you'll probably like the rest of the suite:
 
 ## config & data
 
-XDG dirs, via ricekit's `AppDirs`:
+XDG-style dirs on macOS and Linux; Local AppData on Windows:
 
 | what | where |
 | --- | --- |
-| state (theme, layout) | `~/.local/state/tuistore/state.json` |
-| cache (scraped installs) | `~/.cache/tuistore/` |
-| the catalog | shipped in the package (`tuistore/data/catalog.json`) |
+| state (theme, layout) | `~/.local/state/tuistore/state.json` · `%LOCALAPPDATA%\tuistore\state.json` |
+| cache (scraped installs) | `~/.cache/tuistore/` · `%LOCALAPPDATA%\tuistore\cache\` |
+| refreshed catalog and install ledger | `~/.local/state/tuistore/` · `%LOCALAPPDATA%\tuistore\` |
 
 `tuistore --doctor` prints what your machine looks like to the install engine.
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,0 +1,143 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tuistore import installed, paths, shell
+from tuistore.installer import make
+from tuistore.platform import Env
+
+
+class TestPaths(unittest.TestCase):
+    @mock.patch("tuistore.paths.os.name", "nt")
+    @mock.patch.dict(os.environ, {"LOCALAPPDATA": r"C:\Users\Test\AppData\Local"}, clear=True)
+    def test_user_data_dir_uses_localappdata(self):
+        self.assertEqual(paths.user_data_dir(), Path(r"C:\Users\Test\AppData\Local\tuistore"))
+
+    @mock.patch("tuistore.paths.os.name", "nt")
+    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch("pathlib.Path.home", return_value=Path(r"C:\Users\Test"))
+    def test_user_data_dir_falls_back_to_home_appdata(self, _home):
+        self.assertEqual(paths.user_data_dir(), Path(r"C:\Users\Test\AppData\Local\tuistore"))
+
+    @mock.patch("tuistore.paths.os.name", "nt")
+    @mock.patch.dict(os.environ, {"LOCALAPPDATA": r"C:\Users\Test\AppData\Local"}, clear=True)
+    def test_user_cache_dir_uses_localappdata(self):
+        self.assertEqual(paths.user_cache_dir(), Path(r"C:\Users\Test\AppData\Local\tuistore\cache"))
+
+    @mock.patch("tuistore.paths.os.name", "posix")
+    @mock.patch("pathlib.Path.home", return_value=Path("/home/test"))
+    def test_user_data_dir_uses_xdg_on_unix(self, _home):
+        self.assertTrue(str(paths.user_data_dir()).replace("\\", "/").endswith("/home/test/.local/state/tuistore"))
+
+    @mock.patch("tuistore.paths.os.name", "posix")
+    @mock.patch("pathlib.Path.home", return_value=Path("/home/test"))
+    def test_user_cache_dir_uses_xdg_cache_on_unix(self, _home):
+        self.assertTrue(str(paths.user_cache_dir()).replace("\\", "/").endswith("/home/test/.cache/tuistore"))
+
+    def test_store_dirs_persists_utf8_state_and_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with mock.patch("tuistore.paths.user_data_dir", return_value=root / "state"), \
+                 mock.patch("tuistore.paths.user_cache_dir", return_value=root / "cache"):
+                dirs = paths.StoreDirs()
+                dirs.save_state({"theme": "mocha ✨"})
+                dirs.write_cache("readme", {"text": "🛍️ café"})
+                self.assertEqual(dirs.load_state()["theme"], "mocha ✨")
+                self.assertEqual(dirs.read_cache("readme"), {"text": "🛍️ café"})
+
+
+class TestShellCommand(unittest.TestCase):
+    @mock.patch("tuistore.shell.sys.platform", "win32")
+    @mock.patch("tuistore.shell.shutil.which", side_effect=lambda name: r"C:\pwsh\pwsh.exe" if name == "pwsh" else None)
+    def test_prefers_pwsh_on_windows(self, _which):
+        exe, args = shell.shell_command()
+        self.assertEqual(exe, r"C:\pwsh\pwsh.exe")
+        self.assertEqual(args, ["-NoProfile", "-Command"])
+
+    @mock.patch("tuistore.shell.sys.platform", "win32")
+    @mock.patch("tuistore.shell.shutil.which", side_effect=lambda name: r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" if name == "powershell" else None)
+    def test_falls_back_to_windows_powershell(self, _which):
+        exe, args = shell.shell_command()
+        self.assertTrue(exe.endswith("powershell.exe"))
+        self.assertEqual(args, ["-NoProfile", "-Command"])
+
+    @mock.patch("tuistore.shell.sys.platform", "win32")
+    @mock.patch("tuistore.shell.shutil.which", return_value=None)
+    def test_falls_back_to_cmd_when_no_powershell(self, _which):
+        exe, args = shell.shell_command()
+        self.assertEqual(exe, "cmd.exe")
+        self.assertEqual(args, ["/c"])
+
+    @mock.patch("tuistore.shell.sys.platform", "linux")
+    @mock.patch("tuistore.shell.shutil.which", side_effect=lambda name: "/bin/bash" if name == "bash" else None)
+    def test_uses_bash_on_linux(self, _which):
+        exe, args = shell.shell_command()
+        self.assertEqual(exe, "/bin/bash")
+        self.assertEqual(args, ["-lc"])
+
+    @mock.patch("tuistore.shell.sys.platform", "darwin")
+    @mock.patch("tuistore.shell.shutil.which", side_effect=lambda name: "/bin/zsh" if name == "zsh" else None)
+    def test_prefers_bash_then_zsh_on_macos(self, _which):
+        # bash is checked first; since it is missing, zsh should be selected
+        exe, args = shell.shell_command()
+        self.assertEqual(exe, "/bin/zsh")
+        self.assertEqual(args, ["-lc"])
+
+    @mock.patch("tuistore.shell.sys.platform", "darwin")
+    @mock.patch("tuistore.shell.shutil.which", return_value=None)
+    def test_falls_back_to_sh_on_macos(self, _which):
+        exe, args = shell.shell_command()
+        self.assertEqual(exe, "/bin/sh")
+        self.assertEqual(args, ["-lc"])
+
+
+class TestWindowsInstallEngine(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env = Env("windows", "", set(), tools={"winget", "scoop", "choco"})
+
+    def test_windows_managers_are_available_only_on_windows(self):
+        for kind, command in (
+            ("winget", "winget install --id BurntSushi.ripgrep --exact"),
+            ("scoop", "scoop install ripgrep"),
+            ("choco", "choco install ripgrep"),
+        ):
+            method = make(kind, command)
+            self.assertTrue(method.available(self.env))
+            self.assertFalse(method.available(Env("linux", "ubuntu", {"debian"}, tools={kind})))
+
+    def test_posix_scripts_are_not_offered_on_windows(self):
+        method = make("script", "curl -fsSL https://example.test/install | bash")
+        self.assertFalse(method.available(self.env))
+        self.assertEqual(method.why_unavailable(self.env), "macos/linux only")
+
+    def test_powershell_scripts_are_windows_only(self):
+        method = make("script", "iwr https://example.test/install.ps1 | iex")
+        self.assertTrue(method.available(self.env))
+        self.assertFalse(method.available(Env("linux", "ubuntu", {"debian"}, tools={"curl"})))
+
+    @mock.patch("tuistore.installed._run")
+    def test_windows_manager_scanners_parse_package_names(self, run):
+        run.side_effect = [
+            "Installed apps:\nName Version Source\n---- ------- ------\nripgrep 14.1 main\n",
+            "Name                         Id                    Version\n"
+            "-----------------------------------------------------------\n"
+            "ripgrep                      BurntSushi.ripgrep    14.1\n",
+        ]
+        self.assertEqual(installed._scoop_installed(), {"ripgrep"})
+        self.assertEqual(installed._winget_installed(), {"ripgrep", "burntsushi.ripgrep"})
+
+    @mock.patch("tuistore.installed.os.scandir")
+    @mock.patch("tuistore.installed.os.name", "nt")
+    @mock.patch.dict(os.environ, {"PATH": r"C:\\bin"}, clear=True)
+    def test_path_binaries_normalizes_windows_case_and_extensions(self, scan):
+        entry = mock.Mock()
+        entry.name = "RG.EXE"
+        scan.return_value = [entry]
+        installed.path_binaries.cache_clear()
+        try:
+            self.assertIn("rg.exe", installed.path_binaries())
+            self.assertIn("rg", installed.path_binaries())
+        finally:
+            installed.path_binaries.cache_clear()

--- a/tools/build_catalog.py
+++ b/tools/build_catalog.py
@@ -441,7 +441,7 @@ async def add_methods(entries: list[dict], scrape_top: int) -> None:
 # ── main ─────────────────────────────────────────────────────────────────────
 def load_awesome(local: str | None) -> str:
     if local and Path(local).exists():
-        return Path(local).read_text()
+        return Path(local).read_text(encoding="utf-8")
     print("  fetching awesome-tuis README…")
     with urllib.request.urlopen(AWESOME_URL, timeout=30) as r:
         return r.read().decode("utf-8")
@@ -506,7 +506,7 @@ async def amain(args) -> None:
         "entries": entries,
     }
     OUT.parent.mkdir(parents=True, exist_ok=True)
-    OUT.write_text(json.dumps(doc, indent=1, ensure_ascii=False))
+    OUT.write_text(json.dumps(doc, indent=1, ensure_ascii=False), encoding="utf-8")
     have_methods = sum(1 for e in entries if e.get("methods"))
     print(f"\n  wrote {OUT.relative_to(ROOT)}")
     print(f"  {len(entries)} tools · {have_methods} with install methods · "

--- a/tuistore/__main__.py
+++ b/tuistore/__main__.py
@@ -23,14 +23,18 @@ install flags:  -y/--yes (no prompt)   -f/--force (reinstall)   --dry-run   --me
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
 
+from tuistore.shell import shell_command
+
 
 def _run(cmd: str) -> int:
     print(f"$ {cmd}")
-    return subprocess.run(["/bin/sh", "-lc", cmd]).returncode
+    shell, shell_args = shell_command()
+    return subprocess.run([shell, *shell_args, cmd]).returncode
 
 
 def _confirm(prompt: str, assume_yes: bool) -> bool:
@@ -365,6 +369,15 @@ def _list_installed() -> int:
 
 
 def main() -> None:
+    # Legacy Windows console sessions still default Python's stdio to an ANSI
+    # code page. The catalog and CLI use Unicode (stars, checkmarks, emoji),
+    # so make output deterministic regardless of the user's terminal host.
+    if os.name == "nt":
+        for stream in (sys.stdout, sys.stderr):
+            reconfigure = getattr(stream, "reconfigure", None)
+            if reconfigure:
+                reconfigure(encoding="utf-8", errors="replace")
+
     argv = sys.argv[1:]
     if not argv:
         from .app import main as run

--- a/tuistore/app.py
+++ b/tuistore/app.py
@@ -22,14 +22,14 @@ from textual.widgets.option_list import Option
 
 from ricekit import KitApp, icons, palette
 from ricekit.modals import HelpModal, PickerModal, ThemeModal  # noqa: F401
-from ricekit.storage import AppDirs
 from ricekit.widgets import KitScroll, NavList, Splitter, pop_in
 
 from . import __version__, github, installed as inst, platform
 from .catalog import Catalog, Entry, load, refetch, search
 from .installer import Method, best, rank, run_stream
+from .paths import StoreDirs
 
-DIRS = AppDirs("tuistore")
+DIRS = StoreDirs()
 
 # language → truecolor dot (data color: stays truecolor in every theme)
 LANG_COLOR = {

--- a/tuistore/catalog.py
+++ b/tuistore/catalog.py
@@ -14,6 +14,7 @@ from functools import lru_cache
 from importlib import resources
 
 from .installer import Method, parse_repo
+from .paths import user_data_dir
 
 
 @dataclass
@@ -182,7 +183,7 @@ def search(entries: list[Entry], query: str, *, category: str | None = None,
 # reinstalling the whole package.
 from pathlib import Path  # noqa: E402
 
-USER_CATALOG = Path.home() / ".local/state/tuistore/catalog.json"
+USER_CATALOG = user_data_dir() / "catalog.json"
 CATALOG_URL = (
     "https://raw.githubusercontent.com/Gheat1/tuistore/main/tuistore/data/catalog.json"
 )
@@ -190,7 +191,7 @@ CATALOG_URL = (
 
 def _bundled_text() -> str | None:
     try:
-        return resources.files("tuistore.data").joinpath("catalog.json").read_text()
+        return resources.files("tuistore.data").joinpath("catalog.json").read_text(encoding="utf-8")
     except (FileNotFoundError, ModuleNotFoundError, OSError):
         return None
 
@@ -272,7 +273,7 @@ def load() -> Catalog:
     user = None
     try:
         if USER_CATALOG.exists():
-            user = USER_CATALOG.read_text()
+            user = USER_CATALOG.read_text(encoding="utf-8")
     except OSError:
         user = None
 
@@ -303,7 +304,7 @@ def refetch(url: str = CATALOG_URL, dest: Path = USER_CATALOG) -> tuple[bool, st
         doc = json.loads(raw)  # validate before writing
         n = len(doc.get("entries", []))
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(raw)
+        dest.write_text(raw, encoding="utf-8")
         load.cache_clear()
         return True, f"{n} tools · updated {doc.get('generated_at', '')}"
     except Exception as e:
@@ -323,5 +324,5 @@ def _dedupe(entries: list[Entry]) -> list[Entry]:
 
 
 def load_from(path) -> Catalog:
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return _parse(f.read())

--- a/tuistore/installed.py
+++ b/tuistore/installed.py
@@ -20,14 +20,15 @@ from functools import lru_cache
 from pathlib import Path
 
 from .installer import Method
+from .paths import user_data_dir
 
-LEDGER = Path.home() / ".local/state/tuistore/installed.json"
+LEDGER = user_data_dir() / "installed.json"
 
 
 # ── the ledger ──────────────────────────────────────────────────────────────
 def load_ledger() -> dict:
     try:
-        return json.loads(LEDGER.read_text())
+        return json.loads(LEDGER.read_text(encoding="utf-8"))
     except Exception:
         return {}
 
@@ -35,7 +36,7 @@ def load_ledger() -> dict:
 def save_ledger(data: dict) -> None:
     try:
         LEDGER.parent.mkdir(parents=True, exist_ok=True)
-        LEDGER.write_text(json.dumps(data, indent=1))
+        LEDGER.write_text(json.dumps(data, indent=1), encoding="utf-8")
     except Exception:
         pass
 
@@ -77,6 +78,7 @@ _NOISE = {
     "pacman", "yay", "paru", "apt", "apt-get", "nala", "dnf", "yum", "zypper",
     "xbps-install", "apk", "nix", "nix-env", "flatpak", "snap", "emerge",
     "python", "python3", "-m", "i",
+    "scoop", "choco", "winget",
 }
 
 
@@ -167,6 +169,9 @@ _UNINSTALL = {
     "flatpak": "flatpak uninstall {pkg}",
     "snap": "sudo snap remove {pkg}",
     "go": 'rm -f "$(go env GOPATH)/bin/{bin}"',
+    "scoop": "scoop uninstall {pkg}",
+    "choco": "choco uninstall {pkg}",
+    "winget": "winget uninstall {pkg} --disable-interactivity",
 }
 
 _UPDATE = {
@@ -190,6 +195,9 @@ _UPDATE = {
     "nix": "nix profile upgrade {pkg}",
     "flatpak": "flatpak update {pkg}",
     "snap": "sudo snap refresh {pkg}",
+    "scoop": "scoop update {pkg}",
+    "choco": "choco upgrade {pkg}",
+    "winget": "winget upgrade {pkg} --disable-interactivity",
 }
 
 
@@ -223,14 +231,26 @@ def update_command(rec: dict) -> str | None:
 # ── detection ───────────────────────────────────────────────────────────────
 @lru_cache(maxsize=1)
 def path_binaries() -> frozenset[str]:
-    """Every executable name on PATH — scanned once, cheap to test against."""
+    """Every executable name on PATH — scanned once, cheap to test against.
+
+    On Windows we also strip common executable extensions so that a binary
+    named ``rg.exe`` is recorded simply as ``rg``.
+    """
     found: set[str] = set()
     for d in os.environ.get("PATH", "").split(os.pathsep):
         if not d:
             continue
         try:
             for entry in os.scandir(d):
-                found.add(entry.name)
+                name = entry.name
+                normalized = name.lower() if os.name == "nt" else name
+                found.add(normalized)
+                # On Windows, executables often have extensions; keep both the
+                # raw name and the extension-stripped name for matching.
+                if os.name == "nt" and "." in name:
+                    base, _ext = normalized.rsplit(".", 1)
+                    if base:
+                        found.add(base)
         except OSError:
             continue
     return frozenset(found)
@@ -299,6 +319,51 @@ def _run(cmd: list[str], timeout: float = 25.0) -> str:
         return ""
 
 
+def _scoop_installed() -> set[str]:
+    names = set()
+    for ln in _run(["scoop", "list"]).splitlines():
+        ln = ln.strip()
+        if (ln and not ln.startswith("-") and not ln.startswith("Name")
+                and ln.lower() not in {"installed apps:", "installed apps"}):
+            names.add(ln.split()[0].lower())
+    return names
+
+
+def _choco_installed() -> set[str]:
+    names = set()
+    for ln in _run(["choco", "list", "--local-only", "--limit-output"]).splitlines():
+        if ln.strip() and "|" in ln:
+            names.add(ln.split("|")[0].lower())
+    return names
+
+
+def _winget_installed() -> set[str]:
+    names = set()
+    id_column: int | None = None
+    for ln in _run(["winget", "list", "--disable-interactivity"]).splitlines():
+        lower = ln.lower()
+        if id_column is None and lower.lstrip().startswith("name") and "id" in lower:
+            id_column = lower.index("id")
+            continue
+        if not ln.strip() or set(ln.strip()) <= {"-", " ", "\u2500"}:
+            continue
+        if id_column is not None:
+            # `winget list` is a fixed-width table. Store both display name
+            # and package ID because catalog commands commonly use `--id`.
+            display = ln[:id_column].strip().lower()
+            fields = ln[id_column:].split()
+            if display:
+                names.add(display)
+            if fields:
+                names.add(fields[0].lower())
+            continue
+        # Older winget versions do not reliably expose a table header.
+        parts = ln.split()
+        if parts:
+            names.add(parts[0].lower())
+    return names
+
+
 def _brew_installed() -> set[str]:
     out = _run(["brew", "list", "--formula", "-1"])
     out += "\n" + _run(["brew", "list", "--cask", "-1"])
@@ -349,6 +414,12 @@ def scan_installed(env) -> dict[str, set[str]]:
         out["npm"] = _npm_installed()
     if env.has("cargo"):
         out["cargo"] = _cargo_installed()
+    if "scoop" in env.tools:
+        out["scoop"] = _scoop_installed()
+    if "choco" in env.tools:
+        out["choco"] = _choco_installed()
+    if "winget" in env.tools:
+        out["winget"] = _winget_installed()
     return out
 
 
@@ -368,6 +439,10 @@ _BULK_UPGRADE = [
     ("apt", "sudo apt update && sudo apt upgrade -y", True),
     ("dnf", "sudo dnf upgrade -y", True),
     ("zypper", "sudo zypper update -y", True),
+    # Windows package managers
+    ("scoop", "scoop update *", False),
+    ("choco", "choco upgrade all -y", False),
+    ("winget", "winget upgrade --all --disable-interactivity --accept-source-agreements --accept-package-agreements", False),
 ]
 
 

--- a/tuistore/installer.py
+++ b/tuistore/installer.py
@@ -17,11 +17,11 @@ from __future__ import annotations
 
 import asyncio
 import re
-import shutil
 from dataclasses import dataclass, field
 from typing import AsyncIterator, Iterable
 
 from .platform import Env
+from .shell import shell_command
 
 # ── kind metadata ──────────────────────────────────────────────────────────
 # kind -> (label, preference[lower=better], requires, os allow, family allow)
@@ -52,12 +52,32 @@ KINDS: dict[str, dict] = {
     "snap":     dict(label="snap install",        pref=32, requires=["snap"],    os=["linux"]),
     "docker":   dict(label="docker",              pref=35, requires=["docker"]),
     "podman":   dict(label="podman",              pref=36, requires=["podman"]),
+    # Windows package managers
+    "scoop":    dict(label="scoop install",       pref=37, requires=["scoop"],    os=["windows"]),
+    "choco":    dict(label="choco install",       pref=38, requires=["choco"],    os=["windows"]),
+    "winget":   dict(label="winget install",      pref=39, requires=["winget"],   os=["windows"]),
     "script":   dict(label="install script",      pref=40, requires=["curl"]),
     "source":   dict(label="build from source",   pref=50, requires=["git"]),
     "manual":   dict(label="see README",          pref=99, requires=[]),
 }
 
 _SOURCE_RANK = {"official": 0, "readme": 1, "inferred": 3}
+
+
+def _script_os(command: str) -> list[str] | None:
+    """Return the platform a remote install script targets, when known."""
+    if re.search(r"\b(?:iwr|invoke-webrequest)\b.*\|\s*(?:iex|invoke-expression)\b", command, re.I):
+        return ["windows"]
+    if re.search(r"\b(?:curl|wget)\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b", command):
+        return ["macos", "linux"]
+    return None
+
+
+def _required_tools(method: "Method") -> list[str]:
+    """Dependencies after accounting for a PowerShell-native script."""
+    if method.kind == "script" and _script_os(method.command) == ["windows"]:
+        return []
+    return method.requires
 
 
 @dataclass
@@ -106,11 +126,12 @@ class Method:
         return len(parts) == 2 and parts[0].startswith("git clone ") and parts[1].startswith("cd ")
 
     def available(self, env: Env) -> bool:
-        if self.os and env.os not in self.os:
+        allowed_os = self.os or (_script_os(self.command) if self.kind == "script" else None)
+        if allowed_os and env.os not in allowed_os:
             return False
         if self.families and not (set(self.families) & env.families):
             return False
-        return env.has(*self.requires)
+        return env.has(*_required_tools(self))
 
     def score(self, env: Env) -> tuple:
         pref = KINDS.get(self.kind, {}).get("pref", 60)
@@ -127,11 +148,12 @@ class Method:
         return (0 if self.available(env) else 1, src, pref)
 
     def why_unavailable(self, env: Env) -> str:
-        if self.os and env.os not in self.os:
-            return f"{'/'.join(self.os)} only"
+        allowed_os = self.os or (_script_os(self.command) if self.kind == "script" else None)
+        if allowed_os and env.os not in allowed_os:
+            return f"{'/'.join(allowed_os)} only"
         if self.families and not (set(self.families) & env.families):
             return f"{'/'.join(self.families)} only"
-        missing = [r for r in self.requires if r not in env.tools]
+        missing = [r for r in _required_tools(self) if r not in env.tools]
         if missing:
             return f"needs {' + '.join(missing)}"
         return ""
@@ -188,6 +210,13 @@ def force_variant(kind: str, command: str) -> str:
         return f"{command} --force-reinstall"
     if kind == "brew" and command.strip().startswith("brew install"):
         return command.replace("brew install", "brew reinstall", 1)
+    if kind == "choco" and "--force" not in command:
+        return f"{command} --force"
+    if kind == "winget" and "--force" not in command:
+        return f"{command} --force"
+    if kind == "scoop" and command.strip().startswith("scoop install"):
+        # scoop has no native force flag; uninstall then install
+        return command.replace("scoop install", "scoop uninstall", 1) + " && " + command
     return command  # go/npm/gem/distro managers reinstall on re-run anyway
 
 
@@ -219,7 +248,12 @@ _CLASSIFY = [
     ("brew", re.compile(r"\bbrew\s+install\b")),
     ("docker", re.compile(r"\bdocker\s+(?:run|pull)\b")),
     ("podman", re.compile(r"\bpodman\s+(?:run|pull)\b")),
+    ("scoop", re.compile(r"\bscoop\s+install\b")),
+    ("choco", re.compile(r"\bchoco(?:co)?\s+install\b")),
+    ("winget", re.compile(r"\bwinget\s+install\b")),
+    # remote install scripts: POSIX curl|sh and PowerShell iwr|iex
     ("script", re.compile(r"\bcurl\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b|\bwget\b.*\|\s*(?:sh|bash)\b")),
+    ("script", re.compile(r"(?i)\b(?:iwr|invoke-webrequest)\b.*\|\s*(?:iex|invoke-expression)\b")),
 ]
 
 
@@ -302,10 +336,10 @@ async def run_stream(command: str) -> AsyncIterator[tuple[str, str]]:
     """Execute `command` in a login shell, yielding ("out", line) as it runs
     and finally ("exit", returncode). A login shell is used so the user's
     package managers are on PATH exactly as in their normal terminal."""
-    shell = shutil.which("bash") or shutil.which("zsh") or "/bin/sh"
+    shell, shell_args = shell_command()
     try:
         proc = await asyncio.create_subprocess_exec(
-            shell, "-lc", command,
+            shell, *shell_args, command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )

--- a/tuistore/paths.py
+++ b/tuistore/paths.py
@@ -1,0 +1,84 @@
+"""Cross-platform paths for tuistore data.
+
+On Windows we use %LOCALAPPDATA%\tuistore (the standard roaming-free app-data
+spot). On Unix we keep the existing XDG-style ~/.local/state/tuistore and
+~/.cache/tuistore locations so existing users are unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+import json
+from pathlib import Path
+
+
+def _windows_local_dir() -> Path:
+    return Path(os.environ.get("LOCALAPPDATA") or Path.home() / "AppData" / "Local")
+
+
+def user_data_dir() -> Path:
+    """Directory for persistent state (ledger, catalog)."""
+    if os.name == "nt":
+        return _windows_local_dir() / "tuistore"
+    return Path.home() / ".local/state/tuistore"
+
+
+def user_cache_dir() -> Path:
+    """Directory for cached data (scraped READMEs)."""
+    if os.name == "nt":
+        return _windows_local_dir() / "tuistore" / "cache"
+    return Path.home() / ".cache/tuistore"
+
+
+class StoreDirs:
+    """UTF-8, cross-platform state and cache storage for the TUI.
+
+    ``ricekit.AppDirs`` deliberately follows XDG paths.  Keep that behaviour
+    on Unix, but use Local AppData on Windows and always specify UTF-8 so a
+    catalog or cached README containing emoji is not decoded with the active
+    Windows ANSI code page.
+    """
+
+    def __init__(self) -> None:
+        self.state_file = user_data_dir() / "state.json"
+        self.cache_dir = user_cache_dir()
+
+    def load_state(self) -> dict:
+        try:
+            return json.loads(self.state_file.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+    def save_state(self, patch: dict) -> None:
+        try:
+            data = self.load_state()
+            data.update(patch)
+            self.state_file.parent.mkdir(parents=True, exist_ok=True)
+            self.state_file.write_text(json.dumps(data), encoding="utf-8")
+        except OSError:
+            pass
+
+    def read_cache(self, name: str) -> dict | None:
+        try:
+            return json.loads((self.cache_dir / f"{name}.json").read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+    def write_cache(self, name: str, data: dict) -> None:
+        try:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            (self.cache_dir / f"{name}.json").write_text(
+                json.dumps(data), encoding="utf-8"
+            )
+        except OSError:
+            pass
+
+    def clear_cache(self) -> int:
+        count = 0
+        try:
+            for file in self.cache_dir.glob("*.json"):
+                file.unlink()
+                count += 1
+        except OSError:
+            pass
+        return count

--- a/tuistore/paths.py
+++ b/tuistore/paths.py
@@ -15,7 +15,10 @@ def _is_windows() -> bool:
 
 
 def _windows_local_dir() -> Path:
-    return Path(os.environ.get("LOCALAPPDATA") or Path.home() / "AppData" / "Local")
+    local = os.environ.get("LOCALAPPDATA")
+    if local:
+        return Path(local)
+    return Path.home() / "AppData" / "Local"
 
 
 def user_data_dir() -> Path:

--- a/tuistore/platform.py
+++ b/tuistore/platform.py
@@ -28,8 +28,12 @@ PROBE = [
     "dnf", "yum", "zypper",
     "xbps-install", "emerge", "eopkg", "apk", "pkg",
     "nix", "nix-env", "snap", "flatpak",
+    # Windows package managers
+    "scoop", "choco", "winget",
     # containers + fetchers + build
     "docker", "podman", "curl", "wget", "git", "make", "gcc", "cc",
+    # shells (used for running commands)
+    "pwsh", "powershell",
     # our own helpers
     "gh",
 ]
@@ -97,6 +101,8 @@ class Env:
             return f"macOS ({self.arch})"
         if self.os == "linux":
             return f"{self.distro or 'Linux'} ({self.arch})"
+        if self.os == "windows":
+            return f"Windows ({self.arch})"
         return self.os
 
 
@@ -104,7 +110,7 @@ def _read_os_release() -> dict[str, str]:
     data: dict[str, str] = {}
     for path in ("/etc/os-release", "/usr/lib/os-release"):
         try:
-            for line in Path(path).read_text().splitlines():
+            for line in Path(path).read_text(encoding="utf-8").splitlines():
                 if "=" in line and not line.startswith("#"):
                     k, _, v = line.partition("=")
                     data[k.strip()] = v.strip().strip('"').strip("'")

--- a/tuistore/shell.py
+++ b/tuistore/shell.py
@@ -1,0 +1,28 @@
+"""Cross-platform shell invocation helpers.
+
+Provides a single source of truth for "which shell should run a user-facing
+install command" so that the TUI stream and the CLI `_run` helper behave
+identically on Windows, macOS, and Linux.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+
+
+def shell_command() -> tuple[str, list[str]]:
+    """Return the executable and argument list to run a command in the user's
+    preferred shell.
+
+    On Windows we prefer PowerShell Core, then Windows PowerShell, then
+    cmd.exe. On Unix we use a POSIX login shell (bash, zsh, or /bin/sh).
+    """
+    if sys.platform == "win32":
+        pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if pwsh:
+            # -NoProfile avoids slow startup and prompt/profile side effects.
+            return pwsh, ["-NoProfile", "-Command"]
+        return "cmd.exe", ["/c"]
+    shell = shutil.which("bash") or shutil.which("zsh") or "/bin/sh"
+    return shell, ["-lc"]


### PR DESCRIPTION
## What & why

Adds Windows platform support across shell execution, persistence, package-manager detection, catalog loading, and CLI Unicode output.

## User impact

Windows users can run tuistore from PowerShell or Windows Terminal and use supported Scoop, Chocolatey, and winget install methods.

## Root cause

The app assumed POSIX shells and XDG paths, while Python could decode catalog data and encode CLI output using a Windows ANSI code page.

## Testing

- uv run python -m unittest discover tests -v
- uv run python -m tuistore --doctor
- uv run python -m tuistore search ripgrep