### PR TITLE
Fix update/upgrade CLI dropping tool name when preceded by a flag

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+import tuistore.__main__ as main_module
 from tuistore.__main__ import _cmd_remove
 
 
@@ -16,6 +17,61 @@ class ConfirmationTest(unittest.TestCase):
             _cmd_remove(["tool"])
 
         run.assert_not_called()
+
+
+class UpdateDispatchTest(unittest.TestCase):
+    """`tuistore update`/`upgrade` must find the tool name even when a flag
+    like `-y` precedes it, instead of silently falling back to self-update
+    or a full system upgrade."""
+
+    def _run(self, argv: list[str]):
+        with (
+            patch("tuistore.__main__.sys.argv", argv),
+            patch("tuistore.__main__._update_self", return_value=0) as self_,
+            patch("tuistore.__main__._update_named", return_value=0) as named,
+            patch("tuistore.__main__._system_upgrade", return_value=0) as system,
+            patch("tuistore.__main__._update_installed", return_value=0) as installed,
+        ):
+            with self.assertRaises(SystemExit):
+                main_module.main()
+            return self_, named, system, installed
+
+    def test_update_with_leading_flag_resolves_named_tool(self) -> None:
+        self_, named, system, installed = self._run(["tuistore", "update", "-y", "ripgrep"])
+        named.assert_called_once_with("ripgrep")
+        self_.assert_not_called()
+        system.assert_not_called()
+        installed.assert_not_called()
+
+    def test_upgrade_with_leading_flag_resolves_named_tool(self) -> None:
+        self_, named, system, installed = self._run(["tuistore", "upgrade", "-y", "ripgrep"])
+        named.assert_called_once_with("ripgrep")
+        self_.assert_not_called()
+        system.assert_not_called()
+        installed.assert_not_called()
+
+    def test_bare_update_still_self_updates(self) -> None:
+        self_, named, system, installed = self._run(["tuistore", "update"])
+        self_.assert_called_once()
+        named.assert_not_called()
+        system.assert_not_called()
+        installed.assert_not_called()
+
+    def test_bare_upgrade_still_updates_everything(self) -> None:
+        self_, named, system, installed = self._run(["tuistore", "upgrade"])
+        system.assert_called_once()
+        named.assert_not_called()
+        self_.assert_not_called()
+        installed.assert_not_called()
+
+    def test_special_token_after_flag_still_resolves(self) -> None:
+        self_, named, system, installed = self._run(["tuistore", "update", "-y", "installed"])
+        installed.assert_called_once()
+        named.assert_not_called()
+
+    def test_update_without_flags_still_resolves_named_tool(self) -> None:
+        self_, named, system, installed = self._run(["tuistore", "update", "ripgrep"])
+        named.assert_called_once_with("ripgrep")
 
 
 if __name__ == "__main__":

--- a/tuistore/__main__.py
+++ b/tuistore/__main__.py
@@ -435,7 +435,6 @@ def main() -> None:
 
     a0 = argv[0].lower()
     rest = argv[1:]
-    a1 = rest[0].lower() if rest else ""
 
     if a0 in ("--version", "-v"):
         from . import __version__
@@ -454,12 +453,17 @@ def main() -> None:
     elif a0 in ("info", "show"):
         sys.exit(_cmd_info(rest))
     elif a0 in ("update", "upgrade"):
-        if a1 in ("installed", "tools"):
+        # The tool name (or a special token) may not be rest[0] — flags like
+        # "-y" can precede it, e.g. `tuistore update -y ripgrep`. Scan for the
+        # first argument that isn't a flag rather than only checking rest[0].
+        tool_arg = next((t for t in rest if not t.startswith("-")), None)
+        tool_arg_lower = tool_arg.lower() if tool_arg else ""
+        if tool_arg_lower in ("installed", "tools"):
             sys.exit(_update_installed())
-        if a1 in ("everything", "system", "all"):
+        if tool_arg_lower in ("everything", "system", "all"):
             sys.exit(_system_upgrade())
-        if a1 and not a1.startswith("-"):
-            sys.exit(_update_named(rest[0]))
+        if tool_arg:
+            sys.exit(_update_named(tool_arg))
         # bare `upgrade` = everything on the machine; bare `update` = tuistore
         sys.exit(_system_upgrade() if a0 == "upgrade" else _update_self())
     elif a0 in ("update-installed", "update_installed"):


### PR DESCRIPTION
## Bug

The `update`/`upgrade` CLI dispatcher only looked at `rest[0]` (the first
token after the subcommand) to find the tool name. If a flag like `-y`
preceded the name — e.g. `tuistore update -y ripgrep` — `rest[0]` was
`-y`, which starts with `-`, so the dispatcher fell through to:

- bare self-update (`tuistore update`) when the subcommand was `update`, or
- a full-system upgrade of every package manager on the machine
  (`tuistore upgrade`) when the subcommand was `upgrade`.

`ripgrep` was silently discarded — no error, and a materially different
(and much bigger-blast-radius) action ran instead of what the user asked
for.

Verified before the fix:

```
$ tuistore update -y ripgrep
# dispatched to _update_self() instead of _update_named('ripgrep')
```

## Fix

Scan all of `rest` for the first argument that doesn't start with `-`,
instead of only checking `rest[0]`. That value now drives the same
branches as before:

- `installed` / `tools` → `_update_installed()`
- `everything` / `system` / `all` → `_system_upgrade()`
- any other non-flag token → `_update_named(<token>)`
- no non-flag token at all → the existing bare behavior
  (`_system_upgrade()` for `upgrade`, `_update_self()` for `update`)

This is a minimal, behavior-preserving change: flag position no longer
matters, but everything that worked before (`tuistore update ripgrep`,
`tuistore update installed`, bare `tuistore update`/`upgrade`) is
unaffected.

## Tests

Added `UpdateDispatchTest` in `tests/test_cli.py`:
- `tuistore update -y ripgrep` and `tuistore upgrade -y ripgrep` both
  resolve to `_update_named('ripgrep')` (the regression case).
- Bare `update`/`upgrade` still resolve to self-update / system upgrade.
- A special token (`installed`) appearing after a flag still resolves
  correctly.
- `tuistore update ripgrep` (no flag) still works as before.

Full suite passes: `uv run python -m unittest discover tests -v` →
**Ran 29 tests in 0.712s — OK**.

Also confirmed all top-level modules still import cleanly:
`uv run python -c "import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform"`.