### PR TITLE
Fix scoped npm package names (@scope/name) resolving to empty string

### DIFF
--- a/tests/test_installed.py
+++ b/tests/test_installed.py
@@ -1,0 +1,54 @@
+import unittest
+
+from tuistore.installed import pkg_from_command, uninstall_command, update_command
+
+
+class TestPkgFromCommandScopedNpm(unittest.TestCase):
+    """A leading "@" in an npm-style scoped package (e.g. "@openai/codex")
+    must not be mistaken for a version-pin separator — only a *second* "@"
+    (a trailing "@version") should be stripped."""
+
+    def test_npm_scoped_package_keeps_scope(self):
+        pkg = pkg_from_command("npm", "npm install -g @openai/codex")
+        self.assertEqual(pkg, "@openai/codex")
+
+    def test_pnpm_scoped_package_keeps_scope(self):
+        pkg = pkg_from_command("pnpm", "pnpm add -g @openai/codex")
+        self.assertEqual(pkg, "@openai/codex")
+
+    def test_bun_scoped_package_keeps_scope(self):
+        pkg = pkg_from_command("bun", "bun add -g @openai/codex")
+        self.assertEqual(pkg, "@openai/codex")
+
+    def test_npm_scoped_package_with_version_pin_strips_only_pin(self):
+        pkg = pkg_from_command("npm", "npm install -g @openai/codex@1.2.3")
+        self.assertEqual(pkg, "@openai/codex")
+
+    def test_npm_unscoped_package_with_version_pin_still_strips(self):
+        # unrelated regression guard: plain "pkg@version" pins must still work
+        pkg = pkg_from_command("npm", "npm install -g ripgrep@14.1.0")
+        self.assertEqual(pkg, "ripgrep")
+
+    def test_npm_scoped_package_update_command(self):
+        pkg = pkg_from_command("npm", "npm install -g @openai/codex")
+        rec = {"kind": "npm", "command": "npm install -g @openai/codex", "pkg": pkg or ""}
+        self.assertEqual(update_command(rec), "npm install -g @openai/codex@latest")
+
+    def test_npm_scoped_package_uninstall_command(self):
+        pkg = pkg_from_command("npm", "npm install -g @openai/codex")
+        rec = {"kind": "npm", "command": "npm install -g @openai/codex", "pkg": pkg or ""}
+        self.assertEqual(uninstall_command(rec), "npm uninstall -g @openai/codex")
+
+    def test_pnpm_scoped_package_update_command(self):
+        pkg = pkg_from_command("pnpm", "pnpm add -g @openai/codex")
+        rec = {"kind": "pnpm", "command": "pnpm add -g @openai/codex", "pkg": pkg or ""}
+        self.assertEqual(update_command(rec), "pnpm add -g @openai/codex@latest")
+
+    def test_bun_scoped_package_uninstall_command(self):
+        pkg = pkg_from_command("bun", "bun add -g @openai/codex")
+        rec = {"kind": "bun", "command": "bun add -g @openai/codex", "pkg": pkg or ""}
+        self.assertEqual(uninstall_command(rec), "bun remove -g @openai/codex")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tuistore/installed.py
+++ b/tuistore/installed.py
@@ -86,6 +86,17 @@ _NOISE = {
 _CARGO_VALUE_FLAGS = {"--git", "--branch", "--tag", "--rev", "--path", "--version", "--features"}
 
 
+def _strip_version_pin(token: str) -> str:
+    """Drop a trailing "@version" pin without mistaking a leading "@" npm/jsr
+    scope marker for one, e.g. "pkg@1.2.3" -> "pkg", "@openai/codex" ->
+    unchanged, "@openai/codex@1.2.3" -> "@openai/codex" (strip only the
+    *second* "@", not the first)."""
+    if token.startswith("@"):
+        at = token.find("@", 1)
+        return token if at == -1 else token[:at]
+    return token.split("@", 1)[0]
+
+
 def _cargo_pkg(command: str) -> str | None:
     """Crate name from a `cargo install` command. Git-aware: `--git <url>`
     installs have no crate name in the command line at all (that lives in the
@@ -111,7 +122,7 @@ def _cargo_pkg(command: str) -> str | None:
             continue
         if t.lower() in _NOISE or t.startswith("-"):
             continue
-        return t.split("@")[0]
+        return _strip_version_pin(t)
     return None
 
 
@@ -130,13 +141,13 @@ def pkg_from_command(kind: str, command: str) -> str | None:
         # go install github.com/owner/repo/cmd/tool@latest -> "tool"
         for t in cands:
             if "/" in t or "@" in t:
-                return t.split("@")[0].rstrip("/").split("/")[-1]
-        return cands[-1].split("@")[0] if cands else None
+                return _strip_version_pin(t).rstrip("/").split("/")[-1]
+        return _strip_version_pin(cands[-1]) if cands else None
     # drop bare URLs for non-go managers
     cands = [t for t in cands if not t.startswith("http")]
     if not cands:
         return None
-    pkg = cands[0].split("@")[0]
+    pkg = _strip_version_pin(cands[0])
     # a tap-qualified brew formula (user/tap/formula) installs with the full
     # path but updates/uninstalls with the bare formula name.
     if kind == "brew" and "/" in pkg:


### PR DESCRIPTION
## Bug

`pkg_from_command()` in `tuistore/installed.py` extracted the package name from an install command by stripping everything after the first `"@"` (to drop a version pin, e.g. `"pkg@1.2.3"` -> `"pkg"`). That same logic mishandled npm-scoped package names, which also *start* with `"@"` (e.g. `"@openai/codex"`): the leading `"@"` was treated as the version separator, so the extracted package name came out as an **empty string**.

Repro before the fix:

```
pkg = pkg_from_command('npm', 'npm install -g @openai/codex')
# pkg == ''
update_command({'kind': 'npm', 'command': 'npm install -g @openai/codex', 'pkg': ''})
# None
```

Because `pkg` is empty, `update_command()` and `uninstall_command()` both bail out and return `None`, so once one of these tools is installed, tuistore can no longer offer an update or uninstall for it.

This isn't hypothetical — it breaks real, currently-shipped catalog entries that install via `npm install -g @scope/name`:

- `codex` (`@openai/codex`)
- `crush`, npm method (`@charmland/crush`)
- `inshellisense`, both npm methods (`@microsoft/inshellisense`)
- `Fresh` (`@fresh-editor/fresh-editor`)
- `ghgrab`, npm method (`@ghgrab/ghgrab`)

The same tokenizing path is shared by npm, pnpm, yarn, and bun (they all fall through to the same generic branch in `pkg_from_command`), so scoped installs via any of those managers were equally broken.

## Fix

Only treat `"@"` as a version-pin separator when it is *not* the first character of the token, via a small shared helper:

```python
def _strip_version_pin(token: str) -> str:
    if token.startswith("@"):
        at = token.find("@", 1)
        return token if at == -1 else token[:at]
    return token.split("@", 1)[0]
```

- `"pkg@1.2.3"` -> `"pkg"` (unchanged behavior)
- `"@scope/name"` -> `"@scope/name"` (kept intact)
- `"@scope/name@1.2.3"` -> `"@scope/name"` (strips only the *trailing* pin)

Applied this helper everywhere the old `token.split("@")[0]` pattern was used: the npm/pnpm/yarn/bun path, the `cargo` path, and the `go` path (cargo/go targets never start with `"@"`, so behavior there is unchanged — just kept consistent for future-proofing).

## Tests

Added `tests/test_installed.py` covering:
- `npm install -g @openai/codex` -> package name keeps the scope
- Same for `pnpm add -g @openai/codex` and `bun add -g @openai/codex`
- `@openai/codex@1.2.3` -> strips only the trailing version pin, keeps the scope
- Regression guard: plain `pkg@1.2.3` still strips to `pkg`
- `update_command()` / `uninstall_command()` produce correct, non-`None` commands for scoped npm/pnpm/bun packages

Full suite passes:

```
Ran 32 tests in 0.753s

OK
```

All modules (`tuistore.app`, `tuistore.__main__`, `tuistore.installed`, `tuistore.catalog`, `tuistore.installer`, `tuistore.scrape`, `tuistore.github`, `tuistore.platform`) import cleanly.