### PR TITLE
Fix scrape.py scraping bare "#" comment lines as install commands

### DIFF
--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -19,6 +19,47 @@ docker run --rm mikefarah/yq
             [("brew", ["macos"]), ("apt", ["linux"])],
         )
 
+    def test_rejects_bare_hash_comment_lines(self) -> None:
+        # A bare "# apt install mytool" comment line (no leading distro
+        # label or other text) must not be scraped as a real command: "#"
+        # is a Markdown comment marker here, not a root-shell prompt glyph,
+        # so stripping it before the comment filter runs would otherwise
+        # let it masquerade as a verified README install command.
+        readme = """```sh
+# apt install mytool
+# Fedora: dnf install mytool
+brew install mytool
+```"""
+
+        methods = extract_methods(readme, "https://github.com/someone/mytool")
+
+        self.assertEqual(
+            [(method.kind, method.command) for method in methods],
+            [("brew", "brew install mytool")],
+        )
+
+    def test_still_strips_non_hash_prompt_glyphs(self) -> None:
+        # Regression check for the fix above: "#" no longer counts as a
+        # prompt glyph, but the other shell-prompt conventions ($, the
+        # heavy angle-quote ❯, and the double angle-quote ») must still be
+        # stripped from the front of a command line.
+        readme = """```sh
+$ brew install mytool
+❯ cargo install mytool
+» pip install mytool
+```"""
+
+        methods = extract_methods(readme, "https://github.com/someone/mytool")
+
+        self.assertEqual(
+            sorted((method.kind, method.command) for method in methods),
+            sorted([
+                ("brew", "brew install mytool"),
+                ("cargo", "cargo install mytool"),
+                ("pip", "pip install mytool"),
+            ]),
+        )
+
     def test_accepts_chained_env_and_quoted_var_prefixes(self) -> None:
         # at_start=True must not reject real install lines that happen to
         # have more than a bare sudo/env prefix: a two-step update-then-

--- a/tuistore/scrape.py
+++ b/tuistore/scrape.py
@@ -24,7 +24,13 @@ _INLINE = re.compile(r"`([^`\n]+)`")
 # convention, e.g. `~$ cargo install ...`) directly before the prompt glyph —
 # without it, "~$ cargo install --git ...--force" scrapes with "~$" glued
 # onto the command, which then gets treated as a literal token downstream.
-_PROMPT = re.compile(r"^\s*(?:~[\w./-]*)?(?:\$|#|>|\xe2\x9d\xaf|❯|»|▶)\s+")
+#
+# Note: bare "#" is deliberately NOT treated as a prompt glyph here. Some
+# READMEs use "#" as a root-shell prompt, but Markdown comment lines like
+# "# Debian/Ubuntu: apt install foo" are far more common in the wild, and
+# stripping a leading "#" before the comment filter below runs would let
+# those comment lines masquerade as real, "from README" install commands.
+_PROMPT = re.compile(r"^\s*(?:~[\w./-]*)?(?:\$|>|\xe2\x9d\xaf|❯|»|▶)\s+")
 _MAXLEN = 400
 
 
@@ -37,10 +43,18 @@ def _clean(line: str) -> str:
 def _iter_command_lines(readme: str):
     for block in _FENCE.findall(readme):
         for raw in block.splitlines():
+            # Check for a comment marker on the *raw* line, before any
+            # prompt-glyph stripping, so a leading "#" always means
+            # "comment" and can never first get stripped as a prompt
+            # glyph and then sail past this filter.
+            if raw.strip().startswith("#"):
+                continue
             line = _clean(raw)
-            if line and not line.startswith("#"):
+            if line:
                 yield line
     for inline in _INLINE.findall(readme):
+        if inline.strip().startswith("#"):
+            continue
         line = _clean(inline)
         if line:
             yield line


### PR DESCRIPTION
## Bug

In `tuistore/scrape.py`, `_PROMPT` treated a bare `#` as a shell-prompt
glyph (the root-shell-prompt convention), and `_clean()` stripped it
**before** `_iter_command_lines`'s `not line.startswith("#")` comment
filter ever ran. That ordering meant an ordinary Markdown comment line
inside a fenced code block — e.g. a bare `# apt install mytool` with
nothing else on the line — had its leading `#` stripped first, then
sailed past the comment filter and got scraped as a real, "from README"
install command.

Confirmed before the fix:

```python
readme = """```sh
# apt install mytool
brew install mytool
```"""
extract_methods(readme, "https://github.com/someone/mytool")
# -> [Method(kind="apt", command="apt install mytool", ...),
#     Method(kind="brew", command="brew install mytool", ...)]
```

Only `brew install mytool` is a real command; `# apt install mytool` is
a comment and should not appear in the result.

(Note: a comment line with extra descriptive text before the command,
like `# Debian/Ubuntu: apt install mytool`, does *not* trigger this —
`classify(..., at_start=True)` already requires the install verb to sit
at the very start of the line via `_CMD_PREFIX`, and "Debian/Ubuntu:"
doesn't match that prefix pattern. The real-world failure mode is the
bare `# <command>` comment line with nothing else on it.)

## Fix

- Removed `#` from `_PROMPT` so a leading `#` is never stripped as a
  prompt glyph. Markdown comment lines using `#` are common in READMEs;
  root-shell-prompt-style `#` lines are rare, and I checked
  `tuistore/data/catalog.json`'s existing README-sourced commands (589
  entries) — none of them look like they depend on a `#`-prefixed line
  being treated as a real prompt-stripped command.
- Moved the comment check in `_iter_command_lines` to run against the
  **raw** line before any prompt-glyph stripping, for both fenced-block
  lines and inline-code snippets, so the ordering bug can't resurface
  even if `#` is ever reintroduced to `_PROMPT` for some other reason.

## Tests

Added to `tests/test_scrape.py`:
- `test_rejects_bare_hash_comment_lines`: a fenced block with a bare
  `# apt install mytool` comment, a `# Fedora: dnf install mytool`
  comment, and a real `brew install mytool` line now yields exactly one
  method (`brew`), not three.
- `test_still_strips_non_hash_prompt_glyphs`: regression check that the
  `$`, `❯`, and `»` prompt-glyph stripping (already covered elsewhere
  for `▶`) is unaffected by removing `#` from `_PROMPT`.

Full suite passes: `Ran 25 tests in 0.687s — OK`, and the import smoke
check (`tuistore.app`, `tuistore.__main__`, `tuistore.installed`,
`tuistore.catalog`, `tuistore.installer`, `tuistore.scrape`,
`tuistore.github`, `tuistore.platform`) succeeds.