### PR TITLE
Fix self-update creating a duplicate copy when both uv and pipx are on PATH

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import tuistore.__main__ as main_module
-from tuistore.__main__ import _cmd_remove
+from tuistore.__main__ import _cmd_remove, _self_update_manager, _update_self
 
 
 class ConfirmationTest(unittest.TestCase):
@@ -72,6 +72,68 @@ class UpdateDispatchTest(unittest.TestCase):
     def test_update_without_flags_still_resolves_named_tool(self) -> None:
         self_, named, system, installed = self._run(["tuistore", "update", "ripgrep"])
         named.assert_called_once_with("ripgrep")
+
+
+class SelfUpdateManagerTest(unittest.TestCase):
+    """_self_update_manager must match the manager _how_installed() says
+    actually owns the running copy, not just whichever is available — a
+    pipx-managed copy has uv available too (and vice versa), but picking
+    the wrong one creates a second, parallel copy instead of updating the
+    real one."""
+
+    def test_pipx_owned_copy_prefers_pipx_even_with_uv_available(self) -> None:
+        has = lambda tool: tool in ("uv", "pipx")
+        self.assertEqual(_self_update_manager("pipx", has), "pipx")
+
+    def test_uv_owned_copy_prefers_uv_even_with_pipx_available(self) -> None:
+        has = lambda tool: tool in ("uv", "pipx")
+        self.assertEqual(_self_update_manager("uv", has), "uv")
+
+    def test_owned_manager_missing_from_path_yields_none(self) -> None:
+        # _how_installed() says pipx, but pipx itself isn't on PATH (e.g. a
+        # stale/broken env) — don't silently fall back to uv and create a
+        # second copy; report "can't update" instead.
+        has = lambda tool: tool == "uv"
+        self.assertIsNone(_self_update_manager("pipx", has))
+
+    def test_unknown_falls_back_to_whatever_is_available(self) -> None:
+        has = lambda tool: tool == "pipx"
+        self.assertEqual(_self_update_manager("unknown", has), "pipx")
+
+    def test_unknown_prefers_uv_when_both_available(self) -> None:
+        has = lambda tool: tool in ("uv", "pipx")
+        self.assertEqual(_self_update_manager("unknown", has), "uv")
+
+    def test_unknown_with_neither_available_yields_none(self) -> None:
+        self.assertIsNone(_self_update_manager("unknown", lambda tool: False))
+
+
+class UpdateSelfTest(unittest.TestCase):
+    """End-to-end: _update_self() must run the command for the manager that
+    actually installed this copy, even when a different manager is also on
+    PATH."""
+
+    def test_pipx_install_runs_pipx_even_when_uv_on_path(self) -> None:
+        with (
+            patch("tuistore.__main__._how_installed", return_value="pipx"),
+            patch("tuistore.__main__._install_source", return_value="pypi"),
+            patch("tuistore.__main__.shutil.which", side_effect=lambda t: f"/usr/bin/{t}" if t in ("uv", "pipx") else None),
+            patch("tuistore.__main__._run", return_value=0) as run,
+        ):
+            _update_self()
+
+        run.assert_called_once_with("pipx upgrade tuistore")
+
+    def test_uv_install_runs_uv_even_when_pipx_on_path(self) -> None:
+        with (
+            patch("tuistore.__main__._how_installed", return_value="uv"),
+            patch("tuistore.__main__._install_source", return_value="pypi"),
+            patch("tuistore.__main__.shutil.which", side_effect=lambda t: f"/usr/bin/{t}" if t in ("uv", "pipx") else None),
+            patch("tuistore.__main__._run", return_value=0) as run,
+        ):
+            _update_self()
+
+        run.assert_called_once_with("uv tool upgrade tuistore")
 
 
 if __name__ == "__main__":

--- a/tuistore/__main__.py
+++ b/tuistore/__main__.py
@@ -345,6 +345,26 @@ def _install_source() -> str:
     return "pypi"  # default to the safer, version-gated upgrade path
 
 
+def _self_update_manager(how: str, has) -> str | None:
+    """Pick which manager to run the self-update through.
+
+    Matches the manager that actually owns this copy, per `_how_installed()`
+    ('uv' or 'pipx'), and only falls back to "whichever is available" when
+    `how` is 'unknown' (can't be determined) — so a pipx-managed copy never
+    gets a second, parallel uv-managed copy installed alongside it (or vice
+    versa). `has` reports whether a given manager is available (e.g. on
+    PATH), so callers can supply their own detection (a live `shutil.which`
+    check, a cached `Env.has`, ...).
+    """
+    if how in ("uv", "pipx"):
+        return how if has(how) else None
+    if has("uv"):
+        return "uv"
+    if has("pipx"):
+        return "pipx"
+    return None
+
+
 def _update_self() -> int:
     how = _how_installed()
     if how == "brew":
@@ -356,10 +376,11 @@ def _update_self() -> int:
     # when the version string hasn't changed (uv/pipx upgrades are otherwise
     # version-gated); a PyPI install should use the normal, version-gated
     # upgrade so it never jumps ahead of an actual release.
-    if shutil.which("uv"):
+    mgr = _self_update_manager(how, lambda tool: shutil.which(tool) is not None)
+    if mgr == "uv":
         verb = "install" if src == _SELF_SRC else "upgrade"
         return _run(f"uv tool {verb} {force}{src}".strip())
-    if shutil.which("pipx"):
+    if mgr == "pipx":
         verb = "install --force" if src == _SELF_SRC else "upgrade"
         return _run(f"pipx {verb} {src}")
     print(f"couldn't find uv or pipx — reinstall with:\n  uv tool install {force}{src}".strip())

--- a/tuistore/app.py
+++ b/tuistore/app.py
@@ -1520,11 +1520,12 @@ class StoreApp(KitApp):
         self.push_screen(ManageModal())
 
     def action_update_self(self) -> None:
-        from .__main__ import _how_installed, _install_source, _SELF_SRC
+        from .__main__ import _how_installed, _install_source, _self_update_manager, _SELF_SRC
 
+        how = _how_installed()
         # if this copy was installed via brew, update through brew instead of
         # creating a second, parallel uv/pipx-managed copy alongside it
-        if _how_installed() == "brew":
+        if how == "brew":
             self.push_screen(RunModal(
                 f"{icons.REFRESH} update tuistore", "brew upgrade gheat1/tuistore/tuistore",
                 subtitle="installed via Homebrew — updating with brew instead",
@@ -1537,9 +1538,13 @@ class StoreApp(KitApp):
         # jumps ahead of an actual release onto git's HEAD.
         from_git = _install_source() == "git"
         src = _SELF_SRC if from_git else "tuistore"
-        if self.env.has("uv"):
+        # match the manager that actually owns this copy (see
+        # _self_update_manager) instead of just whichever of uv/pipx happens
+        # to be on PATH, so this doesn't create a second, parallel copy.
+        mgr = _self_update_manager(how, self.env.has)
+        if mgr == "uv":
             cmd = f"uv tool install --force --refresh {src}" if from_git else f"uv tool upgrade {src}"
-        elif self.env.has("pipx"):
+        elif mgr == "pipx":
             cmd = f"pipx install --force {src}" if from_git else f"pipx upgrade {src}"
         else:
             self.notify("need uv or pipx to self-update", severity="warning")


### PR DESCRIPTION
## Bug

`_update_self()` in `tuistore/__main__.py` (and its duplicate, `action_update_self()` in `tuistore/app.py`) exists specifically to update tuistore through whichever manager actually installed it — its own docstring/comments say as much, and it already special-cases a `brew`-detected install to avoid creating a second, parallel copy.

But it only special-cased `brew`. For every other value of `_how_installed()` (`'uv'`, `'pipx'`, or `'unknown'`), it just checked "is `uv` on PATH? then use uv; else is `pipx` on PATH? then use pipx" — completely ignoring which manager `_how_installed()` said actually owns the running copy.

Concretely: if a user's tuistore is installed via pipx but they also have `uv` on their PATH (common), running self-update ran `uv tool upgrade tuistore`, which creates a brand-new, separate uv-managed copy alongside the real pipx-managed one instead of updating it. Same bug in reverse for a uv-owned copy on a machine with pipx also present.

Verified before the fix:

```
$ uv run python -c "
import sys, shutil
import tuistore.__main__ as m
m._how_installed=lambda:'pipx'
real_which=shutil.which
shutil.which=lambda n: '/usr/bin/'+n if n in ('uv','pipx') else real_which(n)
calls=[]
m._run=lambda cmd: calls.append(cmd) or 0
m._install_source=lambda:'pypi'
m._update_self()
print(calls)"
['uv tool upgrade tuistore']   # wrong — real copy is pipx-managed
```

## Fix

Added `_self_update_manager(how, has)` in `tuistore/__main__.py` as the single place this decision is made:

- if `how` is `'uv'` or `'pipx'`, use that manager (only if it's actually available; otherwise report "can't update" rather than silently picking the other one)
- only when `how` is genuinely `'unknown'` does it fall back to "whichever of uv/pipx is available", preserving the old behavior for that case

Both `_update_self()` and `app.py`'s `action_update_self()` now call this shared helper instead of independently duplicating (and, as shown here, diverging on) the same logic. `has` is passed in by the caller so each site can keep its own detection (`shutil.which` in the CLI path, the cached `Env.has` in the TUI path).

After the fix, the same repro now runs `pipx upgrade tuistore` as expected.

## Tests

Added `tests/test_cli.py::SelfUpdateManagerTest` (unit tests on the new helper covering owned-manager-preferred, owned-manager-missing, and unknown-falls-back-to-available cases) and `tests/test_cli.py::UpdateSelfTest` (end-to-end: a pipx-detected install runs a pipx command even when uv is also on PATH, and vice versa).

Full suite passes: `Ran 31 tests in 0.691s — OK`. Also confirmed all modules still import cleanly:
`tuistore.app`, `tuistore.__main__`, `tuistore.installed`, `tuistore.catalog`, `tuistore.installer`, `tuistore.scrape`, `tuistore.github`, `tuistore.platform`.