### PR TITLE
Fix pkg_from_command returning a raw git+ URL as a package name

### DIFF
--- a/tests/test_installed.py
+++ b/tests/test_installed.py
@@ -50,5 +50,78 @@ class TestPkgFromCommandScopedNpm(unittest.TestCase):
         self.assertEqual(uninstall_command(rec), "bun remove -g @openai/codex")
 
 
+class TestPkgFromCommandVcsUrls(unittest.TestCase):
+    """git+https://... / git+ssh://... is the exact syntax uv/pip/pipx use
+    for VCS installs, and the only install method tuistore's own FEATURED
+    catalog entries (NaviTui, ricekit) ship with. `pkg_from_command` must
+    never hand the raw URL back as a "package name" — a real package
+    manager rejects it outright when it's later fed into an uninstall or
+    upgrade command.
+    """
+
+    def test_uv_git_https_install_does_not_return_raw_url(self):
+        cmd = "uv tool install git+https://github.com/Gheat1/NaviTui"
+        pkg = pkg_from_command("uv", cmd)
+        self.assertNotEqual(pkg, "git+https://github.com/Gheat1/NaviTui")
+        # best-effort repo-name guess, matching the featured catalog's real
+        # install target
+        self.assertEqual(pkg, "NaviTui")
+
+    def test_uv_git_https_uninstall_command_is_runnable(self):
+        cmd = "uv tool install git+https://github.com/Gheat1/NaviTui"
+        pkg = pkg_from_command("uv", cmd) or ""
+        rec = {"kind": "uv", "command": cmd, "pkg": pkg}
+        out = uninstall_command(rec)
+        self.assertNotIn("git+", out or "")
+        self.assertEqual(out, "uv tool uninstall NaviTui")
+
+    def test_uv_git_https_update_command_is_runnable(self):
+        cmd = "uv tool install git+https://github.com/Gheat1/ricekit"
+        pkg = pkg_from_command("uv", cmd) or ""
+        rec = {"kind": "uv", "command": cmd, "pkg": pkg}
+        out = update_command(rec)
+        self.assertNotIn("git+", out or "")
+        self.assertEqual(out, "uv tool upgrade ricekit")
+
+    def test_pipx_git_ssh_install_with_ref_and_dot_git_suffix(self):
+        cmd = "pipx install git+ssh://git@github.com/owner/repo.git@main"
+        pkg = pkg_from_command("pipx", cmd)
+        self.assertNotIn("git+", pkg or "")
+        self.assertNotIn("@", pkg or "")
+        self.assertEqual(pkg, "repo")
+
+    def test_pip_git_https_install(self):
+        cmd = "python3 -m pip install git+https://github.com/owner/repo"
+        pkg = pkg_from_command("pip", cmd)
+        self.assertNotEqual(pkg, "git+https://github.com/owner/repo")
+        self.assertEqual(pkg, "repo")
+
+    def test_bare_http_url_still_yields_no_package(self):
+        # unchanged pre-existing behavior: a plain (non git+) URL is not a
+        # package name and we don't guess one either.
+        cmd = "pip install https://example.com/pkg.whl"
+        self.assertIsNone(pkg_from_command("pip", cmd))
+
+
+class TestPkgFromCommandRegularPackages(unittest.TestCase):
+    """Sanity checks that the VCS-URL handling didn't disturb ordinary
+    (non-URL) install commands."""
+
+    def test_uv_plain_package(self):
+        self.assertEqual(pkg_from_command("uv", "uv tool install ripgrep"), "ripgrep")
+
+    def test_npm_plain_package(self):
+        self.assertEqual(pkg_from_command("npm", "npm install -g cowsay"), "cowsay")
+
+    def test_go_install_url(self):
+        cmd = "go install github.com/owner/repo/cmd/tool@latest"
+        self.assertEqual(pkg_from_command("go", cmd), "tool")
+
+    def test_brew_tap_qualified_formula(self):
+        self.assertEqual(
+            pkg_from_command("brew", "brew install user/tap/formula"), "formula"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tuistore/installed.py
+++ b/tuistore/installed.py
@@ -85,6 +85,33 @@ _NOISE = {
 # cargo flags that take a following value — the value is never the crate name
 _CARGO_VALUE_FLAGS = {"--git", "--branch", "--tag", "--rev", "--path", "--version", "--features"}
 
+# pip/uv/pipx VCS install specs (PEP 440 direct references), e.g.
+# "git+https://github.com/owner/repo", "git+ssh://git@host/owner/repo.git@branch"
+_VCS_PREFIXES = ("git+", "hg+", "svn+", "bzr+")
+
+
+def _vcs_repo_name(url: str) -> str | None:
+    """Repo name from a VCS install spec — the same "best available guess"
+    used for `cargo install --git`, since a VCS URL carries no package name
+    of its own on the command line (that lives in the remote project's
+    metadata, which we don't fetch). Strips the `git+` scheme prefix, any
+    `#egg=...`/query fragment, and an `@ref` (branch/tag/commit) suffix —
+    but not an `ssh://user@host` authority, which sits before the final
+    `/repo` segment and is left untouched."""
+    for prefix in _VCS_PREFIXES:
+        if url.startswith(prefix):
+            url = url[len(prefix):]
+            break
+    url = url.split("#", 1)[0].split("?", 1)[0]
+    head, sep, tail = url.rpartition("/")
+    if sep and "@" in tail:
+        tail = tail.split("@", 1)[0]
+    url = f"{head}/{tail}" if sep else tail
+    repo = url.rstrip("/").rsplit("/", 1)[-1]
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    return repo or None
+
 
 def _strip_version_pin(token: str) -> str:
     """Drop a trailing "@version" pin without mistaking a leading "@" npm/jsr
@@ -143,9 +170,17 @@ def pkg_from_command(kind: str, command: str) -> str | None:
             if "/" in t or "@" in t:
                 return _strip_version_pin(t).rstrip("/").split("/")[-1]
         return _strip_version_pin(cands[-1]) if cands else None
-    # drop bare URLs for non-go managers
-    cands = [t for t in cands if not t.startswith("http")]
+    # drop bare URLs and VCS install specs (git+https://..., git+ssh://...)
+    # for non-go managers — neither is a valid package name to feed back into
+    # an uninstall/upgrade command. A VCS spec still gets a best-effort repo
+    # name (see _vcs_repo_name); a bare URL just falls through to the next
+    # candidate, or None if it was the only token.
+    urls = [t for t in cands if t.startswith("http") or t.startswith(_VCS_PREFIXES)]
+    cands = [t for t in cands if t not in urls]
     if not cands:
+        for t in urls:
+            if t.startswith(_VCS_PREFIXES):
+                return _vcs_repo_name(t)
         return None
     pkg = _strip_version_pin(cands[0])
     # a tap-qualified brew formula (user/tap/formula) installs with the full


### PR DESCRIPTION
## Bug

`pkg_from_command()` in `tuistore/installed.py` only filtered out bare URLs
by checking `token.startswith("http")` when deciding what to drop before
picking a "package name" candidate. A VCS install spec such as
`git+https://github.com/owner/repo` starts with `git+`, not `http`, so it
was never filtered — it became the literal "package name", which then got
templated straight into the uninstall/update command.

This is not a theoretical case: `git+https://...` is the exact syntax
uv/pip/pipx use for git installs, and it's the **only** install method the
FEATURED catalog entries **NaviTui** and **ricekit** ship with
(`tools/build_catalog.py`).

Verified against the real `uv` binary before the fix:

```
$ uv run python -c "
from tuistore.installed import pkg_from_command, uninstall_command
cmd='uv tool install git+https://github.com/Gheat1/NaviTui'
pkg=pkg_from_command('uv', cmd)
print('pkg:', repr(pkg))
print(uninstall_command({'kind':'uv','command':cmd,'pkg':pkg or ''}))"
pkg: 'git+https://github.com/Gheat1/NaviTui'
uv tool uninstall git+https://github.com/Gheat1/NaviTui

$ uv tool uninstall "git+https://github.com/Gheat1/NaviTui"
error: invalid value 'git+https://github.com/Gheat1/NaviTui' for '<NAME>...': Not a valid package or extra name: ...
```

Any user who installed NaviTui or ricekit through tuistore would get a
broken "uninstall"/"update" command offered in the UI.

## Fix

- Extend the URL-dropping filter in `pkg_from_command()` to also catch
  tokens that look like a VCS install spec (`git+https://`, `git+ssh://`,
  `git+git://`, and the `hg+`/`svn+`/`bzr+` equivalents), not just bare
  `http(s)://` URLs.
- Rather than just returning `None` for these (safe but unhelpful — no
  uninstall/update ever offered for NaviTui/ricekit), added a best-effort
  fallback `_vcs_repo_name()` that derives the repo name from the URL —
  stripping the VCS scheme prefix, any `#egg=...`/query fragment, an `@ref`
  (branch/tag/commit) suffix, and a trailing `.git`. This mirrors the
  existing `cargo install --git` handling in the same file, which already
  does exactly this "repo name is the best available guess" derivation for
  the same reason (the real package name lives in remote project metadata
  we don't fetch).
- A plain bare URL (not `git+`-prefixed) still yields `None`, matching prior
  behavior — that path is unchanged.

For the verified case above, after the fix:

```
pkg: 'NaviTui'
uv tool uninstall NaviTui
uv tool upgrade NaviTui
```

`NaviTui`/`ricekit` happen to be exactly the derived repo name *and* the
real installed tool name in both cases, so this isn't just "doesn't crash"
— it's the correct uninstall/update command for tuistore's own featured
catalog.

## Tests

Added `tests/test_installed.py` (no test file previously existed for
`pkg_from_command`/`uninstall_command`/`update_command`) covering:
- uv/pipx/pip `git+https://` and `git+ssh://` installs, including an `@ref`
  suffix and a `.git`-suffixed repo, asserting the result is never the raw
  URL and matches the derived repo name.
- `uninstall_command`/`update_command` end-to-end for the exact NaviTui/
  ricekit-style commands, asserting the output contains no `git+` and is a
  concrete runnable command.
- A regression check that a plain (non-`git+`) bare URL still returns
  `None`, unchanged from prior behavior.
- A few sanity checks (uv, npm, go, brew tap-qualified formula) confirming
  ordinary non-URL install commands are unaffected.

Full suite: `uv run python -m unittest discover tests -v` → **Ran 33 tests
in 0.647s — OK** (zero failures/errors). Also confirmed
`import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform`
succeeds cleanly.