### PR TITLE
Fix guessed homebrew fallback surviving alongside real scraped brew method

### DIFF
--- a/tests/test_build_catalog.py
+++ b/tests/test_build_catalog.py
@@ -1,0 +1,75 @@
+import unittest
+
+from tools.build_catalog import dedupe_methods, has_method_kind
+from tuistore.installer import make
+
+
+class GuessedBrewFallbackDedupeTest(unittest.TestCase):
+    """add_methods() appends a guessed `brew install <repo>` fallback for
+    "essential" catalog entries, but only if a real one wasn't already
+    scraped from the README. The scraped command can legitimately differ in
+    shape from the naive guess (e.g. it needs a tap: `brew tap owner/tap &&
+    brew install name` instead of `brew install reponame`), so the check
+    must be "is there already a brew method at all", not "is there already
+    a brew method with this exact command string".
+    """
+
+    def test_scraped_brew_suppresses_guessed_fallback_even_with_different_command(self) -> None:
+        scraped = make(
+            "brew", "brew tap owner/tap && brew install name", source="scraped"
+        ).to_dict()
+        guessed = make(
+            "brew", "brew install name", source="inferred", note="homebrew"
+        ).to_dict()
+
+        # today's bug: both survive because their command strings differ
+        self.assertNotEqual(scraped["command"], guessed["command"])
+
+        # the fixed fallback-append logic must see the scraped brew method
+        # and refuse to add the guessed one at all
+        self.assertTrue(has_method_kind([scraped], "brew"))
+
+        # sanity: without a scraped brew method, the fallback is still needed
+        self.assertFalse(has_method_kind([], "brew"))
+
+        # and the final dedupe pass alone is not sufficient to catch this —
+        # exact-string dedupe lets both through
+        methods = [scraped, guessed]
+        deduped = dedupe_methods(methods)
+        self.assertEqual(len(deduped), 2)
+        self.assertIn(scraped, deduped)
+        self.assertIn(guessed, deduped)
+
+    def test_essential_fallback_logic_end_to_end(self) -> None:
+        # mirrors add_methods()'s do(): scraped/inferred methods collected
+        # first, then the guessed brew fallback appended only if no brew
+        # method exists yet, then the final dedupe pass.
+        scraped = make(
+            "brew", "brew tap owner/tap && brew install name", source="scraped"
+        ).to_dict()
+        methods = [scraped]
+
+        if not has_method_kind(methods, "brew"):
+            methods.append(
+                make("brew", "brew install name", source="inferred", note="homebrew")
+                .to_dict()
+            )
+
+        result = dedupe_methods(methods)
+
+        brew_methods = [m for m in result if m["kind"] == "brew"]
+        self.assertEqual(len(brew_methods), 1)
+        self.assertEqual(brew_methods[0]["command"], scraped["command"])
+        self.assertEqual(brew_methods[0]["source"], "scraped")
+
+    def test_dedupe_methods_keeps_first_of_exact_duplicates(self) -> None:
+        m1 = make("cargo", "cargo install foo", source="scraped").to_dict()
+        m2 = make("cargo", "cargo install foo", source="inferred").to_dict()
+
+        deduped = dedupe_methods([m1, m2])
+
+        self.assertEqual(deduped, [m1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/build_catalog.py
+++ b/tools/build_catalog.py
@@ -455,6 +455,25 @@ async def enrich(entries: list[dict], chunk: int = 40) -> None:
 
 
 # ── 4/5. install methods ─────────────────────────────────────────────────────
+def has_method_kind(methods: list[dict], kind: str) -> bool:
+    """True if the methods list already has an entry of the given kind,
+    regardless of what its command string is."""
+    return any(m["kind"] == kind for m in methods)
+
+
+def dedupe_methods(methods: list[dict]) -> list[dict]:
+    """Dedupe by (kind, command), keeping the first occurrence — best source
+    wins by insertion order."""
+    seen = set()
+    deduped = []
+    for m in methods:
+        k = (m["kind"], m["command"])
+        if k not in seen:
+            seen.add(k)
+            deduped.append(m)
+    return deduped
+
+
 async def add_methods(entries: list[dict], scrape_top: int) -> None:
     # rank github entries by stars for scraping budget
     ranked = sorted(
@@ -491,20 +510,16 @@ async def add_methods(entries: list[dict], scrape_top: int) -> None:
         for m in infer_methods(e["url"], e.get("language")):
             methods.append(m.to_dict())
         # essentials get a homebrew method — they're almost all in brew, and it's
-        # what most people (and Mac users) reach for. Scraped brew, if any, wins.
-        if e.get("_essential"):
+        # what most people (and Mac users) reach for. Scraped brew, if any, wins:
+        # only guess one if nothing already scraped/inferred a brew method,
+        # since a real command (e.g. a tap-qualified install) won't string-match
+        # the naive guess below and must not be allowed to coexist with it.
+        if e.get("_essential") and not has_method_kind(methods, "brew"):
             owner, repo = parse_repo(e["url"])
             formula = ESSENTIAL_BREW.get(f"{owner}/{repo}", repo.lower())
             methods.append(make("brew", f"brew install {formula}",
                                 source="inferred", note="homebrew").to_dict())
-        # dedupe by (kind, command), keep first (best source wins by order)
-        seen = set()
-        deduped = []
-        for m in methods:
-            k = (m["kind"], m["command"])
-            if k not in seen:
-                seen.add(k)
-                deduped.append(m)
+        deduped = dedupe_methods(methods)
         if deduped:
             e["methods"] = deduped
 


### PR DESCRIPTION
## Bug

In `tools/build_catalog.py`, `add_methods()` builds each catalog entry's
`methods` list and dedupes it by exact `(kind, command)` string equality.
For "essential" entries it also appends a guessed `brew install <repo>`
fallback unconditionally, with a comment claiming "Scraped brew, if any,
wins" — implying the dedupe pass handles precedence.

That's not what happens. When the README-scraped brew command differs in
*shape* from the naive guess — e.g. the real formula needs a tap:
`brew tap owner/tap && brew install name` instead of the guessed
`brew install name` — the two command strings never match. Since the
dedupe key is `(kind, command)`, not just `kind`, **both** the correct
scraped method and the wrong guessed one survive into the same catalog
entry.

## Fix

Change the fallback-append check itself: only add the guessed brew
method if the entry doesn't already have *any* method of kind `"brew"`,
rather than relying on an exact-command dedupe to catch it after the
fact. The general `(kind, command)` dedupe pass is left as-is for
everything else, since other kinds can legitimately have multiple
distinct commands (e.g. more than one valid `shell`/`cargo` install
line from a README).

Factored both pieces of logic out into small top-level functions so
they're independently testable:

- `has_method_kind(methods, kind)` — used by the fallback-append check
- `dedupe_methods(methods)` — the existing final dedupe pass, unchanged
  in behavior

## Tests

Added `tests/test_build_catalog.py`, which:

- reproduces the exact bug scenario (a scraped tap-qualified brew
  command + a guessed bare `brew install X` command) and confirms only
  the scraped one survives with the fix
- checks `has_method_kind` and `dedupe_methods` directly
- adds a case confirming the general exact-duplicate dedupe still keeps
  the first occurrence

Full suite passes:

```
Ran 26 tests in 0.671s

OK
```

Also confirmed the module imports cleanly:

```
uv run python -c "import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform"
```