### PR TITLE
Fix pkg_from_command always returning "global" for yarn installs

### DIFF
--- a/tests/test_installed.py
+++ b/tests/test_installed.py
@@ -1,6 +1,16 @@
+import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
-from tuistore.installed import pkg_from_command, uninstall_command, update_command
+from tuistore.installed import (
+    load_ledger,
+    pkg_from_command,
+    record_install,
+    uninstall_command,
+    update_command,
+)
+from tuistore.installer import Method
 
 
 class TestPkgFromCommandScopedNpm(unittest.TestCase):
@@ -121,6 +131,46 @@ class TestPkgFromCommandRegularPackages(unittest.TestCase):
         self.assertEqual(
             pkg_from_command("brew", "brew install user/tap/formula"), "formula"
         )
+
+
+class TestYarnPackageParsing(unittest.TestCase):
+    """yarn's only recognized install shape is `yarn global add <pkg>`
+    (see installer.py's yarn regex/kind). The bare word "global" used to be
+    missing from _NOISE, so it was picked up as the package name instead of
+    the real target — every yarn install recorded "global" as its package."""
+
+    def test_pkg_from_command_ignores_bare_global(self):
+        self.assertEqual(
+            pkg_from_command("yarn", "yarn global add ripgrep-cli"), "ripgrep-cli"
+        )
+
+    def test_pkg_from_command_ignores_bare_global_other_pkg(self):
+        self.assertEqual(
+            pkg_from_command("yarn", "yarn global add fkill-cli"), "fkill-cli"
+        )
+
+    def test_record_install_stores_real_package_not_global(self):
+        method = Method(kind="yarn", command="yarn global add ripgrep-cli")
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger_path = Path(tmp) / "installed.json"
+            with mock.patch("tuistore.installed.LEDGER", ledger_path):
+                record_install("ripgrep-cli", "ripgrep-cli", method)
+                rec = load_ledger()["ripgrep-cli"]
+        self.assertEqual(rec["pkg"], "ripgrep-cli")
+        self.assertEqual(rec["bin"], "ripgrep-cli")
+        self.assertNotEqual(rec["pkg"], "global")
+
+    def test_uninstall_command_uses_real_package_name(self):
+        rec = {"kind": "yarn", "pkg": "ripgrep-cli", "bin": "ripgrep-cli"}
+        self.assertEqual(uninstall_command(rec), "yarn global remove ripgrep-cli")
+        self.assertNotIn("global remove global", uninstall_command(rec))
+
+    def test_update_command_uses_real_package_name(self):
+        rec = {"kind": "yarn", "pkg": "ripgrep-cli", "bin": "ripgrep-cli"}
+        cmd = update_command(rec)
+        self.assertIsNotNone(cmd)
+        self.assertIn("ripgrep-cli", cmd)
+        self.assertNotIn("global add global", cmd)
 
 
 if __name__ == "__main__":

--- a/tuistore/installed.py
+++ b/tuistore/installed.py
@@ -79,6 +79,16 @@ _NOISE = {
     "xbps-install", "apk", "nix", "nix-env", "flatpak", "snap", "emerge",
     "python", "python3", "-m", "i",
     "scoop", "choco", "winget",
+    # bare (non-flag) "global" is yarn's subcommand in its only recognized
+    # install shape, "yarn global add <pkg>" (see installer.py's yarn
+    # pattern) — without this, pkg_from_command('yarn', ...) always returns
+    # "global" instead of the package name. There IS a real npm package
+    # literally named "global" (an env-var helper library, not a CLI), so
+    # `yarn global add global` would still be misparsed — but it was already
+    # broken before this fix (it resolved to the same wrong answer, "global",
+    # either way), no such package appears in tuistore's catalog of CLI/TUI
+    # tools, and this is by far the common case yarn is actually used for.
+    "global",
 }
 
 
@@ -232,6 +242,7 @@ _UPDATE = {
     "brew": "brew upgrade {pkg}",
     "npm": "npm install -g {pkg}@latest",
     "pnpm": "pnpm add -g {pkg}@latest",
+    "yarn": "yarn global add {pkg}@latest",
     "gem": "gem update {pkg}",
     "pacman": "sudo pacman -S {pkg}",
     "yay": "yay -S {pkg}",


### PR DESCRIPTION
## Bug

yarn's only recognized install shape (`installer.py`'s yarn pattern) is:

```
yarn global add <pkg>
```

`_NOISE` in `tuistore/installed.py` excluded the *flag* form `--global`, but not
the bare subcommand word `global` that actually appears in this shape. Since
`global` sits right before the real package name and isn't stripped, `pkg_from_command`
picks it up as the "package":

```
>>> pkg_from_command('yarn', 'yarn global add ripgrep-cli')
'global'          # should be 'ripgrep-cli'
```

This means **every** yarn install tuistore records gets `pkg = "global"` in the
ledger, `bin = "global"`, and any derived command (e.g. uninstall) targets the
wrong thing:

```
>>> uninstall_command({"kind": "yarn", "pkg": "global", "bin": "global"})
'yarn global remove global'   # instead of 'yarn global remove ripgrep-cli'
```

## Fix

Add the bare word `"global"` to `_NOISE` so it's skipped exactly like the other
manager/subcommand tokens already in that set (mirrors how `"add"`, `"install"`,
`"tool"`, etc. are handled). Documented in a comment why this is safe: there is
a real npm package literally named `global` (an unrelated env-var helper
library), so `yarn global add global` is still technically ambiguous — but it
resolved to the same wrong value before this fix too, no such entry exists in
tuistore's catalog of CLI/TUI tools, and it's a corner case, not the common
path this fix addresses.

While verifying the fix end-to-end I also noticed `_UPDATE` (the update-command
table) never had a `"yarn"` entry at all — `_UNINSTALL` has had `"yarn global
remove {pkg}"` since yarn support was added, but the matching update command
was simply missing, so `update_command()` always returned `None` for
yarn-installed tools regardless of this bug. Added `"yarn": "yarn global add
{pkg}@latest"`, mirroring the existing `npm`/`pnpm` entries.

## Testing

Added `tests/test_installed.py`:
- `pkg_from_command('yarn', 'yarn global add X')` returns `X` for two different package names
- `record_install` writes the real package name (not `"global"`) into the ledger
- `uninstall_command` / `update_command` for a yarn record reference the real package name, not `"global"`

Full suite passes:

```
Ran 28 tests in 0.630s
OK
```

Also confirmed all top-level modules still import cleanly:
```
python -c "import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform"
```