### PR TITLE
Fix classify() mis-tagging "uv pip install X" as plain pip

### DIFF
--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,6 +1,8 @@
 import unittest
 
-from tuistore.installer import classify, make
+from tuistore.catalog import Entry, _prefer_uv
+from tuistore.installed import pkg_from_command, uninstall_command, update_command
+from tuistore.installer import KINDS, classify, force_variant, make
 from tuistore.platform import Env
 
 
@@ -41,6 +43,70 @@ class TestDnfYumClassification(unittest.TestCase):
         env = Env("linux", "fedora", {"fedora", "rhel"}, "x86_64", tools={"dnf"})
         method = make("dnf", "sudo dnf install mytool", source="readme")
         self.assertTrue(method.available(env))
+
+
+class TestClassifyUvPip(unittest.TestCase):
+    """`uv pip install X` runs the `uv` binary, not pip3 — it must not be
+    tagged as a plain `pip` install (github.com/Gheat1/tuistore issue: wrong
+    `requires` sends users who lack pip3 but have uv down a dead end)."""
+
+    def test_uv_pip_install_classifies_as_uv_pip_not_pip(self):
+        self.assertEqual(classify("uv pip install ruff"), "uv-pip")
+
+    def test_uv_pip_install_requires_uv_not_pip3(self):
+        method = make(classify("uv pip install ruff"), "uv pip install ruff", source="readme")
+        self.assertIn("uv", method.requires)
+        self.assertNotIn("pip3", method.requires)
+
+    def test_uv_pip_install_label_mentions_uv_not_bare_pip(self):
+        method = make(classify("uv pip install ruff"), "uv pip install ruff", source="readme")
+        self.assertIn("uv", method.label)
+        self.assertNotEqual(method.label, KINDS["pip"]["label"])
+
+    def test_plain_pip_install_is_unaffected(self):
+        # regression guard: the generic pip pattern must still win for real
+        # pip invocations once the more specific uv-pip pattern is checked
+        # first and doesn't match.
+        self.assertEqual(classify("pip install ruff"), "pip")
+        self.assertEqual(classify("pip3 install ruff"), "pip")
+        self.assertEqual(classify("python3 -m pip install ruff"), "pip")
+
+    def test_uv_tool_install_and_uvx_are_unaffected(self):
+        self.assertEqual(classify("uv tool install ruff"), "uv")
+        self.assertEqual(classify("uvx install ruff"), "uv")
+        self.assertEqual(classify("uv install ruff"), "uv")
+
+    def test_uv_pip_install_with_flags_and_sudo_prefix(self):
+        self.assertEqual(classify("uv pip install --system ruff"), "uv-pip")
+        self.assertEqual(classify("sudo uv pip install ruff"), "uv-pip")
+
+    def test_pkg_name_extracted_from_uv_pip_command(self):
+        self.assertEqual(pkg_from_command("uv-pip", "uv pip install ruff"), "ruff")
+
+    def test_force_variant_uses_reinstall_flag(self):
+        forced = force_variant("uv-pip", "uv pip install ruff")
+        self.assertIn("--reinstall", forced)
+
+    def test_uninstall_and_update_commands_use_uv_not_pip(self):
+        rec = {"kind": "uv-pip", "pkg": "ruff", "bin": "ruff"}
+        uninstall = uninstall_command(rec)
+        update = update_command(rec)
+        self.assertIsNotNone(uninstall)
+        self.assertIsNotNone(update)
+        self.assertTrue(uninstall.startswith("uv "))
+        self.assertTrue(update.startswith("uv "))
+        self.assertNotIn("pip3", uninstall)
+        self.assertNotIn("pip3", update)
+
+    def test_prefer_uv_still_canonicalizes_from_uv_pip_readme_method(self):
+        # a README that recommends `uv pip install X` should still feed the
+        # catalog's "make uv tool install the default" canonicalization.
+        entry = Entry(name="Ruff", url="https://github.com/astral-sh/ruff")
+        entry.methods = [make("uv-pip", "uv pip install ruff", source="readme")]
+        _prefer_uv(entry)
+        uv_methods = [m for m in entry.methods if m.kind == "uv"]
+        self.assertEqual(len(uv_methods), 1)
+        self.assertEqual(uv_methods[0].command, "uv tool install ruff")
 
 
 if __name__ == "__main__":

--- a/tuistore/catalog.py
+++ b/tuistore/catalog.py
@@ -210,7 +210,7 @@ def _prefer_uv(entry: Entry) -> None:
 
     best_src, best_pkg = None, None
     for m in entry.methods:
-        if m.kind in ("uv", "pipx", "pip"):
+        if m.kind in ("uv", "uv-pip", "pipx", "pip"):
             pkg = pkg_from_command(m.kind, m.command)
             if pkg and (best_src is None
                         or _SRC_ORDER.get(m.source, 9) < _SRC_ORDER.get(best_src, 9)):

--- a/tuistore/installed.py
+++ b/tuistore/installed.py
@@ -205,6 +205,7 @@ _UNINSTALL = {
     "cargo": "cargo uninstall {pkg}",
     "cargo-binstall": "cargo uninstall {pkg}",
     "uv": "uv tool uninstall {pkg}",
+    "uv-pip": "uv pip uninstall {pkg}",
     "pipx": "pipx uninstall {pkg}",
     "pip": "python3 -m pip uninstall -y {pkg}",  # portable: many boxes have pip3, not pip
     "brew": "brew uninstall {pkg}",
@@ -237,6 +238,7 @@ _UPDATE = {
     "cargo": "cargo install {pkg} --force",
     "cargo-binstall": "cargo binstall {pkg} --force",
     "uv": "uv tool upgrade {pkg}",
+    "uv-pip": "uv pip install -U {pkg}",
     "pipx": "pipx upgrade {pkg}",
     "pip": "python3 -m pip install -U {pkg}",
     "brew": "brew upgrade {pkg}",

--- a/tuistore/installer.py
+++ b/tuistore/installer.py
@@ -27,6 +27,7 @@ from .shell import shell_command
 # kind -> (label, preference[lower=better], requires, os allow, family allow)
 KINDS: dict[str, dict] = {
     "uv":       dict(label="uv tool install",     pref=5,  requires=["uv"]),
+    "uv-pip":   dict(label="uv pip install",       pref=16, requires=["uv"]),
     "cargo-binstall": dict(label="cargo binstall", pref=6, requires=["cargo-binstall"]),
     "brew":     dict(label="brew install",       pref=8,  requires=["brew"]),
     "cargo":    dict(label="cargo install",       pref=10, requires=["cargo"]),
@@ -208,6 +209,8 @@ def force_variant(kind: str, command: str) -> str:
         return f"{command} --force"
     if kind == "pip" and "--force-reinstall" not in command:
         return f"{command} --force-reinstall"
+    if kind == "uv-pip" and "--reinstall" not in command:
+        return f"{command} --reinstall"
     if kind == "brew" and command.strip().startswith("brew install"):
         return command.replace("brew install", "brew reinstall", 1)
     if kind == "choco" and "--force" not in command:
@@ -225,6 +228,7 @@ _CLASSIFY = [
     ("cargo-binstall", re.compile(r"\bcargo\s+binstall\b")),
     ("cargo", re.compile(r"\bcargo\s+install\b")),
     ("uv", re.compile(r"\buv\s+tool\s+install\b|\buvx?\s+install\b")),
+    ("uv-pip", re.compile(r"\buv\s+pip\s+install\b")),
     ("pipx", re.compile(r"\bpipx\s+install\b")),
     ("pip", re.compile(r"\bpip3?\s+install\b|\bpython3?\s+-m\s+pip\s+install\b")),
     ("go", re.compile(r"\bgo\s+install\b")),


### PR DESCRIPTION
## Bug

`classify()` in `tuistore/installer.py` had no pattern for `uv pip install X`. The existing `uv` pattern only matches `uv tool install …` or bare `uv(x) install …`, so a line like `uv pip install ruff` fell through and matched the generic `pip` pattern instead (which matches `pip install` as a substring anywhere in the line). That mis-tagged the method as `kind="pip"`, `requires=["pip3"]`, even though the command actually invokes the `uv` binary — so a machine that has `uv` but not `pip3` would incorrectly show the method as unavailable (or, worse, a machine with a stray `pip3` but no working `uv`-managed Python would offer a command that doesn't do what its `requires`/label claim).

Repro before the fix:
```
$ uv run python -c "
from tuistore.installer import classify, make
cmd='uv pip install ruff'
kind=classify(cmd)
m=make(kind, cmd, source='readme')
print(kind, m.requires, m.label)"
pip ['pip3'] pip install
```

## Fix

- Added a new `uv-pip` kind to `KINDS` (label `"uv pip install"`, `requires=["uv"]`), distinct from the existing `uv` kind (`"uv tool install"`) so the UI label stays accurate — `uv tool install` and `uv pip install` are different commands and showing the wrong label next to the actual command text would be confusing.
- Added a `classify()` pattern for `uv pip install` that's checked *before* the generic `pip` pattern (list order = first match wins), so `uv pip install X` now classifies as `uv-pip` with `requires=["uv"]`.
- Wired the new kind through the other places that switch on `kind` for consistency (so it isn't a half-supported kind):
  - `force_variant`: reinstall uses `--reinstall` (uv's actual flag, not pip's `--force-reinstall`).
  - `installed.py` `_UNINSTALL`/`_UPDATE` templates: `uv pip uninstall {pkg}` / `uv pip install -U {pkg}`.
  - `catalog._prefer_uv()`: a README that recommends `uv pip install X` still feeds the catalog's "make `uv tool install` the default for Python tools" package-name inference (previously that logic only looked at `uv`/`pipx`/`pip` kinds).

After the fix:
```
uv-pip ['uv'] uv pip install
```

## Tests

Added `tests/test_installer.py` with coverage for: `uv pip install` classifying as `uv-pip` (not `pip`), `requires` containing `uv` and not `pip3`, the label, that plain `pip install`/`pip3 install`/`python3 -m pip install` and `uv tool install`/`uvx install` are unaffected, flag/sudo-prefixed variants, package-name extraction, the `--reinstall` force variant, the uninstall/update command templates, and the `_prefer_uv` interaction.

Full suite:
```
$ uv run python -m unittest discover tests -v
...
Ran 33 tests in 0.7s

OK
```

Also verified all modules still import cleanly:
```
uv run python -c "import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform"
```

Checked the shipped `tuistore/data/catalog.json` for any pre-scraped entries that were mis-tagged by the old bug (`kind == "pip"` with `uv pip` in the command) — there are none, so no data migration is needed.