### PR TITLE
Fix classify() dropping wget|sudo bash install scripts

### DIFF
--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -109,5 +109,29 @@ class TestClassifyUvPip(unittest.TestCase):
         self.assertEqual(uv_methods[0].command, "uv tool install ruff")
 
 
+class ClassifyScriptTest(unittest.TestCase):
+    def test_curl_pipe_sudo_bash_is_a_script(self) -> None:
+        self.assertEqual(
+            classify("curl -fsSL https://example.com/install.sh | sudo bash"),
+            "script",
+        )
+
+    def test_wget_pipe_sudo_bash_is_a_script(self) -> None:
+        # Regression: the wget branch of the script regex previously lacked
+        # the optional `sudo` that the curl branch already allowed, so a
+        # documented `wget ... | sudo bash` install line silently failed to
+        # classify (returned None) while the equivalent curl form worked.
+        self.assertEqual(
+            classify("wget -qO- https://example.com/install.sh | sudo bash"),
+            "script",
+        )
+
+    def test_wget_pipe_sh_without_sudo_is_still_a_script(self) -> None:
+        self.assertEqual(
+            classify("wget -qO- https://example.com/install.sh | sh"),
+            "script",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tuistore/installer.py
+++ b/tuistore/installer.py
@@ -256,7 +256,7 @@ _CLASSIFY = [
     ("choco", re.compile(r"\bchoco(?:latey)?\s+install\b")),
     ("winget", re.compile(r"\bwinget\s+install\b")),
     # remote install scripts: POSIX curl|sh and PowerShell iwr|iex
-    ("script", re.compile(r"\bcurl\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b|\bwget\b.*\|\s*(?:sh|bash)\b")),
+    ("script", re.compile(r"\bcurl\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b|\bwget\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b")),
     ("script", re.compile(r"(?i)\b(?:iwr|invoke-webrequest)\b.*\|\s*(?:iex|invoke-expression)\b")),
 ]
 


### PR DESCRIPTION
## Bug

The `script` kind's combined classification regex in `tuistore/installer.py` allowed an optional `sudo` between the pipe and `sh`/`bash` on the **curl** branch, but not on the **wget** branch:

```python
("script", re.compile(r"\bcurl\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b|\bwget\b.*\|\s*(?:sh|bash)\b")),
```

As a result, `classify("wget -qO- https://example.com/install.sh | sudo bash")` returned `None` instead of `"script"`, while the equivalent `curl ... | sudo bash` classified correctly. Concretely:

```
curl: script
wget: None   <- should also be 'script'
```

Since `classify()` decides whether a README-scraped command line is recognized as an install method at all, this silently dropped a documented, legitimate install option any time a project's README happened to use `wget` piped into `sudo bash`/`sh` instead of `curl`.

## Fix

Add the same optional `(?:sudo\s+)?` to the wget branch of the script regex so both branches are symmetric:

```python
("script", re.compile(r"\bcurl\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b|\bwget\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b")),
```

(The related `_script_os()` helper used for platform-gating already had this symmetric, so this brings `classify()` in line with it.)

## Tests

Added `tests/test_installer.py` with a `ClassifyScriptTest` covering:
- `curl ... | sudo bash` → `"script"` (pre-existing correct behavior, now explicitly pinned)
- `wget ... | sudo bash` → `"script"` (regression test for this bug — failed before the fix)
- `wget ... | sh` (no sudo) → `"script"` (existing behavior still works)

Full suite passes: `Ran 26 tests in 0.682s / OK`. Also verified all core modules still import cleanly (`tuistore.app`, `tuistore.__main__`, `tuistore.installed`, `tuistore.catalog`, `tuistore.installer`, `tuistore.scrape`, `tuistore.github`, `tuistore.platform`).