### PR TITLE
Fix: Homebrew detection matched any path containing "cellar", not a real Cellar path

### DIFF
--- a/tests/test_how_installed.py
+++ b/tests/test_how_installed.py
@@ -1,0 +1,80 @@
+import unittest
+from unittest.mock import patch
+
+from tuistore.__main__ import _how_installed, _is_homebrew_cellar_path
+
+
+class IsHomebrewCellarPathTest(unittest.TestCase):
+    """Unit tests on the pure path-matching helper (no filesystem/symlink
+    resolution involved, so these are stable across platforms)."""
+
+    def test_cellar_substring_outside_homebrew_prefix_is_rejected(self) -> None:
+        # "cellar" appears in the path, but it's a user/project directory
+        # (e.g. a backups folder), not a real Homebrew Cellar install.
+        path = "/users/gheat/mycellar-backups/tuistore/bin/tuistore"
+        self.assertFalse(_is_homebrew_cellar_path(path))
+
+    def test_cellar_as_substring_of_unrelated_word_is_rejected(self) -> None:
+        path = "/home/gheat/projects/cellardoor/bin/tuistore"
+        self.assertFalse(_is_homebrew_cellar_path(path))
+
+    def test_real_cellar_path_apple_silicon_is_accepted(self) -> None:
+        path = "/opt/homebrew/cellar/tuistore/1.2.3/bin/tuistore"
+        self.assertTrue(_is_homebrew_cellar_path(path))
+
+    def test_real_cellar_path_intel_is_accepted(self) -> None:
+        path = "/usr/local/cellar/tuistore/1.2.3/bin/tuistore"
+        self.assertTrue(_is_homebrew_cellar_path(path))
+
+    def test_real_cellar_path_linuxbrew_is_accepted(self) -> None:
+        path = "/home/linuxbrew/.linuxbrew/cellar/tuistore/1.2.3/bin/tuistore"
+        self.assertTrue(_is_homebrew_cellar_path(path))
+
+
+class HowInstalledTest(unittest.TestCase):
+    """End-to-end tests through `_how_installed`, which resolves the
+    `which("tuistore")` path before classifying it."""
+
+    def _how_installed_for(self, which_path: str) -> str:
+        # `_how_installed` runs the `which()` result through `Path.resolve()`,
+        # which normalizes separators/anchoring per host OS (e.g. it would
+        # prepend a drive letter on Windows). Stub it to a no-op so these
+        # fixed POSIX-style test paths behave the same on every platform
+        # this suite runs on (this repo's CI includes windows-latest).
+        with (
+            patch("tuistore.__main__.shutil.which", return_value=which_path),
+            patch("pathlib.Path.resolve", lambda self: self),
+        ):
+            return _how_installed()
+
+    def test_cellar_substring_outside_homebrew_prefix_is_not_brew(self) -> None:
+        path = "/Users/gheat/mycellar-backups/tuistore/bin/tuistore"
+        self.assertNotEqual(self._how_installed_for(path), "brew")
+
+    def test_real_homebrew_cellar_path_apple_silicon_is_brew(self) -> None:
+        path = "/opt/homebrew/Cellar/tuistore/1.2.3/bin/tuistore"
+        self.assertEqual(self._how_installed_for(path), "brew")
+
+    def test_real_homebrew_cellar_path_intel_is_brew(self) -> None:
+        path = "/usr/local/Cellar/tuistore/1.2.3/bin/tuistore"
+        self.assertEqual(self._how_installed_for(path), "brew")
+
+    def test_real_homebrew_cellar_path_linuxbrew_is_brew(self) -> None:
+        path = "/home/linuxbrew/.linuxbrew/Cellar/tuistore/1.2.3/bin/tuistore"
+        self.assertEqual(self._how_installed_for(path), "brew")
+
+    def test_uv_tool_path_is_uv(self) -> None:
+        path = "/Users/gheat/.local/share/uv/tools/tuistore/bin/tuistore"
+        self.assertEqual(self._how_installed_for(path), "uv")
+
+    def test_pipx_path_is_pipx(self) -> None:
+        path = "/Users/gheat/.local/pipx/venvs/tuistore/bin/tuistore"
+        self.assertEqual(self._how_installed_for(path), "pipx")
+
+    def test_unknown_path_is_unknown(self) -> None:
+        path = "/usr/bin/tuistore"
+        self.assertEqual(self._how_installed_for(path), "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tuistore/__main__.py
+++ b/tuistore/__main__.py
@@ -303,6 +303,19 @@ def _cmd_info(args: list[str]) -> int:
 # ── existing verbs ──────────────────────────────────────────────────────────
 _SELF_SRC = "git+https://github.com/Gheat1/tuistore"
 
+# Known Homebrew install prefixes (macOS Apple Silicon, macOS Intel, Linuxbrew).
+# A real Homebrew install always resolves to <prefix>/Cellar/<formula>/....
+_HOMEBREW_PREFIXES = ("/opt/homebrew/", "/usr/local/", "/home/linuxbrew/.linuxbrew/")
+
+
+def _is_homebrew_cellar_path(low_path: str) -> bool:
+    """True only for a path shaped like a real Homebrew Cellar install —
+    a `Cellar` directory component directly under a known Homebrew prefix —
+    not merely any path that happens to contain "cellar" as a substring
+    (e.g. a project or backup directory named "mycellar-backups")."""
+    normalized = low_path.replace("\\", "/")  # tolerate a resolve()'d Windows-style path
+    return any(normalized.startswith(prefix + "cellar/") for prefix in _HOMEBREW_PREFIXES)
+
 
 def _how_installed() -> str:
     """Guess which manager owns the running `tuistore`, from its resolved
@@ -314,7 +327,7 @@ def _how_installed() -> str:
     except OSError:
         pass
     low = path.lower()
-    if "cellar" in low or "linuxbrew" in low:
+    if _is_homebrew_cellar_path(low):
         return "brew"
     if "/uv/tools/" in low or "\\uv\\tools\\" in low:
         return "uv"


### PR DESCRIPTION
## Bug

`_how_installed()` in `tuistore/__main__.py` decides which package manager owns the running `tuistore` binary, from its resolved path — this decision drives `tuistore update` (self-update): a brew-owned install gets `brew upgrade`'d, others get reinstalled via `uv`/`pipx`.

The Homebrew check was a raw, unscoped substring test:

```python
if "cellar" in low or "linuxbrew" in low:
    return "brew"
```

Any resolved binary path that merely *contains* the substring `"cellar"` anywhere — case-insensitively — got classified as a Homebrew install, even when it has nothing to do with Homebrew. For example:

- `/Users/x/mycellar-backups/tuistore/bin/tuistore` (a backups directory)
- `/home/x/projects/cellardoor/bin/tuistore` (an unrelated project name)

Both would be misclassified as `"brew"`, and `tuistore update` would then shell out to `brew upgrade gheat1/tuistore/tuistore` against a binary Homebrew never installed — instead of updating the copy the user actually has.

## Fix

Added `_is_homebrew_cellar_path()`, which only matches a `Cellar` path *component* sitting directly under one of Homebrew's known install prefixes:

- `/opt/homebrew/` (macOS, Apple Silicon)
- `/usr/local/` (macOS, Intel)
- `/home/linuxbrew/.linuxbrew/` (Linuxbrew)

i.e. it requires the resolved path to look like `<prefix>/Cellar/<formula>/...`, not just contain the letters "cellar" somewhere. `_how_installed()` now calls this helper instead of the bare substring test.

## Testing

Added `tests/test_how_installed.py`:
- Direct unit tests on `_is_homebrew_cellar_path()` confirming a "cellar"-containing-but-unrelated path is rejected, while real Cellar paths (Apple Silicon / Intel / Linuxbrew) are accepted.
- End-to-end tests through `_how_installed()` (mocking `shutil.which`, with `Path.resolve()` stubbed to identity so the tests are platform-independent, since this repo's CI matrix includes `windows-latest`) covering the same brew cases plus `uv`, `pipx`, and `unknown`.

Full suite:

```
Ran 35 tests in 0.676s

OK
```

Import sanity check also passes:

```
python -c "import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform"
```