### PR TITLE
build_catalog: stop featured entries from stealing scrape-budget slots

### DIFF
--- a/tests/test_build_catalog.py
+++ b/tests/test_build_catalog.py
@@ -1,6 +1,14 @@
+import asyncio
+import sys
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-from tools.build_catalog import dedupe_methods, has_method_kind
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from tools import build_catalog  # noqa: E402
+from tools.build_catalog import dedupe_methods, has_method_kind  # noqa: E402
 from tuistore.installer import make
 
 
@@ -69,6 +77,51 @@ class GuessedBrewFallbackDedupeTest(unittest.TestCase):
         deduped = dedupe_methods([m1, m2])
 
         self.assertEqual(deduped, [m1])
+
+
+class FeaturedScrapeBudgetTest(unittest.TestCase):
+    def test_featured_entries_never_consume_a_scrape_budget_slot(self) -> None:
+        # Two high-star featured entries used to be ranked alongside real
+        # entries, sliced into the top-N scrape budget, and only *then*
+        # excluded for being featured — leaving their slots unused instead
+        # of falling through to the next real candidate. With a budget of
+        # 2 and featured-a/featured-b ranked #1 and #2 by stars, the buggy
+        # version scraped nothing at all even though real-1..real-3 were
+        # available to fill the budget.
+        entries = [
+            dict(name="featured-a", url="https://github.com/org/featured-a",
+                 stars=9000, featured=True),
+            dict(name="featured-b", url="https://github.com/org/featured-b",
+                 stars=8000, featured=True),
+            dict(name="real-1", url="https://github.com/org/real-1", stars=500),
+            dict(name="real-2", url="https://github.com/org/real-2", stars=400),
+            dict(name="real-3", url="https://github.com/org/real-3", stars=300),
+        ]
+
+        scraped_urls: list[str] = []
+
+        async def fake_scrape_repo(url: str) -> list:
+            scraped_urls.append(url)
+            return []
+
+        with patch.object(build_catalog.scrape, "scrape_repo", fake_scrape_repo):
+            asyncio.run(build_catalog.add_methods(entries, scrape_top=2))
+
+        # The budget of 2 must be fully spent on real candidates (the two
+        # highest-starred non-featured entries), not silently shrunk by the
+        # featured entries occupying and then vacating ranking slots.
+        self.assertEqual(
+            sorted(scraped_urls),
+            sorted([
+                "https://github.com/org/real-1",
+                "https://github.com/org/real-2",
+            ]),
+        )
+        self.assertEqual(len(scraped_urls), 2)
+
+        # Featured entries never get scraped regardless of star rank.
+        self.assertNotIn("https://github.com/org/featured-a", scraped_urls)
+        self.assertNotIn("https://github.com/org/featured-b", scraped_urls)
 
 
 if __name__ == "__main__":

--- a/tools/build_catalog.py
+++ b/tools/build_catalog.py
@@ -475,14 +475,17 @@ def dedupe_methods(methods: list[dict]) -> list[dict]:
 
 
 async def add_methods(entries: list[dict], scrape_top: int) -> None:
-    # rank github entries by stars for scraping budget
+    # rank github entries by stars for scraping budget. Featured entries are
+    # excluded here, before the top-N slice is taken, so one of them ranking
+    # highly can't occupy a budget slot that then goes unused — the next
+    # real (non-featured) candidate must be able to fill it instead.
+    # Featured tools keep only their hand-curated official methods — no
+    # scraped/inferred noise (e.g. a monorepo README's sibling-package installs)
     ranked = sorted(
-        (e for e in entries if parse_repo(e["url"])),
+        (e for e in entries if parse_repo(e["url"]) and not e.get("featured")),
         key=lambda e: -(e.get("stars") or 0),
     )
-    # featured tools keep only their hand-curated official methods — no
-    # scraped/inferred noise (e.g. a monorepo README's sibling-package installs)
-    scrape_set = {id(e) for e in ranked[:scrape_top] if not e.get("featured")}
+    scrape_set = {id(e) for e in ranked[:scrape_top]}
     # always scrape the hand-picked essentials so they get verified installs
     scrape_set |= {id(e) for e in entries if e.get("_essential")}
 


### PR DESCRIPTION
## The bug

In `tools/build_catalog.py`, `add_methods()` computes the README-scrape budget like this (before this fix):

```python
ranked = sorted(
    (e for e in entries if parse_repo(e["url"])),
    key=lambda e: -(e.get("stars") or 0),
)
scrape_set = {id(e) for e in ranked[:scrape_top] if not e.get("featured")}
```

`ranked` is built from *all* entries, including featured ones. The top-N slice (`ranked[:scrape_top]`) is taken first, and only afterwards are featured entries filtered out of that slice. Featured entries always return early with just their hand-curated methods and are never actually scraped — so when a featured entry ranks within the top-N by stars, it occupies one of the N budget slots, that slot is then discarded (not scraped, since it's featured), and the next real, non-featured candidate just below the cutoff never gets pulled in to replace it. Effective scrape coverage silently shrinks by exactly the number of highly-ranked featured entries.

## The fix

Exclude featured entries from the ranking list comprehension itself, before the top-N slice is taken, so the slice only ever contains genuine scrape candidates and the budget is fully spent:

```python
ranked = sorted(
    (e for e in entries if parse_repo(e["url"]) and not e.get("featured")),
    key=lambda e: -(e.get("stars") or 0),
)
scrape_set = {id(e) for e in ranked[:scrape_top]}
```

## Test

Added `tests/test_build_catalog.py`, which builds a synthetic entry list with two high-star `featured=True` entries ranked #1 and #2 by stars, plus three real entries ranked #3-#5, and calls `add_methods(entries, scrape_top=2)` with `scrape.scrape_repo` mocked out (no network). It asserts the two highest-starred *real* entries get scraped.

- Against the old code this test fails: nothing gets scraped at all (both budget slots go to the featured entries and are then dropped).
- Against the fixed code it passes: `real-1` and `real-2` are scraped, exactly filling the budget of 2.

## Test suite

Full suite passes:

```
uv run python -m unittest discover tests -v
...
Ran 24 tests in 0.719s

OK
```

And the import smoke check passes:

```
uv run python -c "import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform"
```