### PR TITLE
publish: don't push pre-release GitHub Releases to real PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,13 @@ jobs:
 
   publish:
     needs: build
+    # Guard against publishing pre-release/RC GitHub Releases to real PyPI.
+    # The `release: published` event fires for both normal releases and
+    # ones explicitly marked "pre-release" — github.event.release.prerelease
+    # distinguishes them. `!= true` (rather than `== false`) also lets this
+    # job run on manual workflow_dispatch, where github.event.release is
+    # unset and the expression evaluates to null.
+    if: github.event.release.prerelease != true
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -1,0 +1,116 @@
+"""Regression test for .github/workflows/publish.yml.
+
+GitHub's `release` event's `published` activity type fires both for a
+normal release AND for a release explicitly marked "pre-release" when it
+is created (see GitHub's webhook/event docs). Without an explicit guard,
+the `publish` job — which uploads to real PyPI via Trusted Publishing —
+would run for pre-release/RC GitHub Releases too, with no way for a
+maintainer to cut a pre-release without also shipping it to real PyPI.
+
+This test parses the workflow file (kept dependency-free: no PyYAML, just
+indentation-aware text parsing, since PyYAML is not a project dependency)
+and asserts that the `publish` job carries a guard referencing
+`github.event.release.prerelease` that skips the job when the release is
+a pre-release, while still permitting non-release triggers (e.g. the
+`workflow_dispatch` trigger this workflow also declares).
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parent.parent / ".github" / "workflows" / "publish.yml"
+)
+
+
+def _job_block(text: str, job_name: str) -> str:
+    """Return the raw text of a top-level job's body (2-space-indented job
+    key; body is everything indented deeper, up to the next job or EOF)."""
+    lines = text.splitlines()
+    header = re.compile(rf"^  {re.escape(job_name)}:\s*$")
+    start = next((i for i, line in enumerate(lines) if header.match(line)), None)
+    assert start is not None, f"job {job_name!r} not found in {WORKFLOW_PATH}"
+
+    body = []
+    for line in lines[start + 1 :]:
+        if line.strip() == "":
+            body.append(line)
+            continue
+        # A new top-level job (or `jobs:` sibling) starts at <= 2-space
+        # indent with a non-blank, non-comment line.
+        if re.match(r"^  \S", line):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+class PublishWorkflowPrereleaseGuardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(
+            WORKFLOW_PATH.is_file(), f"workflow file missing: {WORKFLOW_PATH}"
+        )
+        self.text = WORKFLOW_PATH.read_text()
+
+    def test_release_trigger_uses_published_type(self) -> None:
+        # Sanity check the assumption this guard depends on: the trigger is
+        # the `published` activity type, which GitHub fires for both
+        # regular and pre-release releases.
+        self.assertRegex(self.text, r"release:\s*\n\s*types:\s*\[published\]")
+
+    def test_publish_job_is_guarded_against_prerelease(self) -> None:
+        publish_block = _job_block(self.text, "publish")
+
+        if_lines = [
+            line.strip()
+            for line in publish_block.splitlines()
+            if re.match(r"^\s*if:", line)
+        ]
+        self.assertTrue(
+            if_lines,
+            "publish job has no `if:` guard — a GitHub Release marked "
+            "pre-release will be published to real PyPI just like a "
+            "stable release",
+        )
+
+        guard = if_lines[0]
+        self.assertIn(
+            "github.event.release.prerelease",
+            guard,
+            f"publish job guard does not reference the release's prerelease "
+            f"flag: {guard!r}",
+        )
+
+        # The guard must actively exclude pre-releases (e.g. `!= true`,
+        # `== false`, or a leading `!`), not just mention the field.
+        negates_prerelease = bool(
+            re.search(r"prerelease\s*!=\s*true", guard)
+            or re.search(r"prerelease\s*==\s*false", guard)
+            or re.search(r"!\s*github\.event\.release\.prerelease\b", guard)
+        )
+        self.assertTrue(
+            negates_prerelease,
+            f"publish job guard does not appear to exclude pre-releases: {guard!r}",
+        )
+
+    def test_publish_job_guard_permits_non_release_triggers(self) -> None:
+        # This workflow also supports `workflow_dispatch`, where
+        # `github.event.release` is unset. The guard must not be written in
+        # a way (e.g. `== false`) that would also block manual runs.
+        publish_block = _job_block(self.text, "publish")
+        guard = next(
+            line.strip()
+            for line in publish_block.splitlines()
+            if re.match(r"^\s*if:", line)
+        )
+        self.assertNotIn(
+            "prerelease == false",
+            guard,
+            "guard uses `== false`, which evaluates to false (skipping the "
+            "job) on workflow_dispatch runs where github.event.release is "
+            "unset; use `!= true` instead",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`.github/workflows/publish.yml` triggers on:

```yaml
on:
  release:
    types: [published]
```

GitHub's own event docs confirm the `published` activity type fires for **both** a normal release and a release explicitly marked "pre-release" at creation time. Neither the `build` nor `publish` job had any check on `github.event.release.prerelease`, so there was no way for a maintainer to cut a pre-release/RC GitHub Release without it being automatically published to real PyPI via Trusted Publishing — identical to a stable release.

## The fix

Add a job-level guard on `publish` (the job that actually performs the upload via `pypa/gh-action-pypi-publish`):

```yaml
publish:
  needs: build
  if: github.event.release.prerelease != true
  runs-on: ubuntu-latest
  ...
```

Notes on scoping/expression choice:

- Gated at the **job** level rather than a single step, since `publish`'s only step is the actual PyPI upload — there's nothing else in that job worth running for a pre-release.
- Left the `build` job unguarded — building the sdist/wheel and uploading it as a workflow artifact is harmless for a pre-release, and keeping it available can be useful for manual inspection.
- Used `!= true` rather than `== false` so the job still runs on the workflow's `workflow_dispatch` trigger, where `github.event.release` is unset and the expression evaluates to `null` (`null != true` → `true`; whereas `null == false` → `false`, which would silently skip manual dispatch runs too).

## Verification

This can't be exercised by triggering an actual GitHub Actions run locally, so it was verified as follows:

1. **YAML validity + Actions expression syntax**: ran [`actionlint`](https://github.com/rhysd/actionlint) (v1.7.12, installed via Homebrew) against the workflow — `actionlint .github/workflows/*.yml` exits 0 with zero findings, confirming both the YAML and the `if:` expression syntax are valid.
2. **Convention check**: there are no other `if:` conditions anywhere else in this repo's workflows to match against, so the unwrapped `github.event.x == y` form (no `${{ }}` needed for a bare job-level `if:`) follows GitHub's own documented convention for job/step conditionals.
3. **Manual parse check**: also loaded the YAML with `pyyaml` (`uv run --with pyyaml python -c "yaml.safe_load(...)"`) to confirm the file parses and the `if:` key lands under the `publish` job with the expected string value.
4. **New unit test** (`tests/test_publish_workflow.py`): parses the workflow file's `publish` job block and asserts it carries an `if:` guard referencing `github.event.release.prerelease` that actively excludes pre-releases (not just `== false`, which would also block `workflow_dispatch`). I confirmed this test **fails** against the pre-fix version of the file (`StopIteration` / `AssertionError` — no guard found) and **passes** against the fixed version.

Full local test suite:

```
$ uv run python -m unittest discover tests -v
...
----------------------------------------------------------------------
Ran 26 tests in 0.689s

OK
```

Import sanity check also passes:

```
$ uv run python -c "import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform"
all modules import cleanly
```