### PR TITLE
ci: add macos-latest to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -1,0 +1,100 @@
+"""macOS/Homebrew-specific behavior — mirrors tests/test_windows.py.
+
+None of this logic depends on actually running on a Mac (it's all mocked),
+but it exercises the code paths that only matter on macOS: Homebrew
+detection/parsing and the "installed via brew, update with brew instead"
+self-update branch. Historically these paths ran on Linux/Windows CI only,
+so a real macOS-only regression here could ship without any red build.
+"""
+
+import unittest
+from unittest import mock
+
+from tuistore import installed, platform
+
+
+class TestPlatformDetectsMacOS(unittest.TestCase):
+    def tearDown(self) -> None:
+        platform.detect.cache_clear()
+
+    @mock.patch("tuistore.platform.shutil.which", return_value=None)
+    @mock.patch("tuistore.platform._platform.machine", return_value="arm64")
+    @mock.patch("tuistore.platform._platform.system", return_value="Darwin")
+    def test_darwin_system_maps_to_macos(self, _system, _machine, _which):
+        platform.detect.cache_clear()
+        env = platform.detect()
+        self.assertEqual(env.os, "macos")
+        self.assertEqual(env.arch, "arm64")
+        self.assertEqual(env.label, "macOS (arm64)")
+
+    @mock.patch("tuistore.platform.shutil.which", return_value=None)
+    @mock.patch("tuistore.platform._platform.machine", return_value="x86_64")
+    @mock.patch("tuistore.platform._platform.system", return_value="Darwin")
+    def test_intel_mac_arch_is_normalized(self, _system, _machine, _which):
+        platform.detect.cache_clear()
+        env = platform.detect()
+        self.assertEqual(env.os, "macos")
+        self.assertEqual(env.arch, "x86_64")
+
+    @mock.patch("tuistore.platform.shutil.which", return_value=None)
+    @mock.patch("tuistore.platform._platform.machine", return_value="arm64")
+    @mock.patch("tuistore.platform._platform.system", return_value="Darwin")
+    def test_macos_has_no_distro_or_families(self, _system, _machine, _which):
+        platform.detect.cache_clear()
+        env = platform.detect()
+        self.assertEqual(env.distro, "")
+        self.assertEqual(env.families, set())
+
+
+class TestHowInstalledDetectsHomebrew(unittest.TestCase):
+    @mock.patch("tuistore.__main__.shutil.which",
+                return_value="/opt/homebrew/Cellar/tuistore/1.2.3/bin/tuistore")
+    def test_apple_silicon_cellar_path_is_brew(self, _which):
+        from tuistore.__main__ import _how_installed
+        self.assertEqual(_how_installed(), "brew")
+
+    @mock.patch("tuistore.__main__.shutil.which",
+                return_value="/usr/local/Cellar/tuistore/1.2.3/bin/tuistore")
+    def test_intel_mac_cellar_path_is_brew(self, _which):
+        from tuistore.__main__ import _how_installed
+        self.assertEqual(_how_installed(), "brew")
+
+    @mock.patch("tuistore.__main__.shutil.which",
+                return_value="/home/linuxbrew/.linuxbrew/bin/tuistore")
+    def test_linuxbrew_path_is_brew(self, _which):
+        from tuistore.__main__ import _how_installed
+        self.assertEqual(_how_installed(), "brew")
+
+    @mock.patch("tuistore.__main__.shutil.which",
+                return_value="/Users/me/.local/bin/tuistore")
+    def test_non_brew_path_is_not_brew(self, _which):
+        from tuistore.__main__ import _how_installed
+        self.assertNotEqual(_how_installed(), "brew")
+
+
+class TestUpdateSelfPrefersBrew(unittest.TestCase):
+    @mock.patch("tuistore.__main__._run", return_value=0)
+    @mock.patch("tuistore.__main__._how_installed", return_value="brew")
+    def test_brew_installed_copy_updates_via_brew_upgrade(self, _how, run):
+        from tuistore.__main__ import _update_self
+        rc = _update_self()
+        run.assert_called_once_with("brew upgrade gheat1/tuistore/tuistore")
+        self.assertEqual(rc, 0)
+
+
+class TestBrewInstalledScanner(unittest.TestCase):
+    @mock.patch("tuistore.installed._run")
+    def test_parses_and_merges_formula_and_cask_listings(self, run):
+        run.side_effect = ["ripgrep\nlazygit\n", "iterm2\n"]
+        names = installed._brew_installed()
+        self.assertEqual(names, {"ripgrep", "lazygit", "iterm2"})
+
+    @mock.patch("tuistore.installed._run")
+    def test_lowercases_and_skips_blank_lines(self, run):
+        run.side_effect = ["Ripgrep\n\n", "\n"]
+        names = installed._brew_installed()
+        self.assertEqual(names, {"ripgrep"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`tests.yml`'s matrix only runs on `ubuntu-latest` and `windows-latest` — `macos-latest` was never included, despite 16+ macOS/Homebrew-specific code references across `tuistore/*.py`:

- `installer.py` — the `brew` install-method kind and command templates
- `installed.py` — `_brew_installed()` (parses `brew list --formula -1` / `--cask -1`), the `brew uninstall {pkg}` / `brew upgrade {pkg}` templates, and the tap-qualified formula (`user/tap/formula`) handling
- `__main__.py` — `_how_installed()`'s Homebrew-detection heuristic (`"cellar" in low or "linuxbrew" in low`) and the `"installed via Homebrew — updating with brew instead"` branch of `_update_self()`
- `app.py` — the matching UI branch that offers `brew upgrade` instead of the normal self-update path
- `platform.py` — the `Darwin -> "macos"` branch of `detect()`

None of this ever ran under CI because there was no macOS runner in the matrix. This is the same class of gap (a platform-specific code path never exercised by CI) that previously let a real Gentoo/emerge lifecycle bug ship completely undetected.

## Fix

Add `macos-latest` to the `os` matrix in `.github/workflows/tests.yml`. Everything else in the workflow (uv setup, `unittest discover`, import sanity check, catalog sanity check) already runs per-OS, so this is a one-line change that gives real coverage on macOS for free.

This is expected to increase the CI job count by 3 (one per Python version: 3.11/3.12/3.13). **A maintainer should watch the first run** — since these Homebrew/macOS code paths have literally never run in CI before, it's plausible (and would be a genuinely useful outcome of closing this gap, not a sign this PR is wrong) that the first `macos-latest` run surfaces a real latent macOS-only failure.

## Test coverage

Added `tests/test_macos.py` (mirroring the existing `tests/test_windows.py` pattern) to directly cover the previously-untested Homebrew/macOS logic with mocks, independent of the CI matrix change:

- `platform.detect()` correctly maps `Darwin` → `"macos"` and normalizes both Apple Silicon (`arm64`) and Intel (`x86_64`) arches
- `_how_installed()` recognizes Apple Silicon (`/opt/homebrew/Cellar/...`), Intel (`/usr/local/Cellar/...`), and Linuxbrew (`/home/linuxbrew/.linuxbrew/...`) paths as `"brew"`, and does not misclassify a non-brew path
- `_update_self()` takes the `brew upgrade gheat1/tuistore/tuistore` branch when installed via Homebrew
- `_brew_installed()` correctly parses and merges `brew list --formula -1` and `brew list --cask -1` output, lowercasing and skipping blank lines

## Verification

- `.github/workflows/tests.yml` YAML parses cleanly (`yaml.safe_load`) and the matrix now lists `['ubuntu-latest', 'windows-latest', 'macos-latest']`.
- Full suite run on this (macOS) machine as a strong proxy for what an actual `macos-latest` CI job will do:

```
$ uv run python -m unittest discover tests -v
...
----------------------------------------------------------------------
Ran 33 tests in 0.717s

OK
```

- Import sanity check passes:

```
$ uv run python -c "import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform; print('all modules import cleanly')"
all modules import cleanly
```