### PR TITLE
Fix PATH loss when running install commands via a login shell on Debian/Ubuntu

### DIFF
--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -117,6 +117,14 @@ class TestShellPathRestoration(unittest.TestCase):
     """
 
     def setUp(self):
+        if os.name == "nt":
+            # shell_command() never returns bash on Windows (pwsh/powershell/
+            # cmd.exe instead, where wrap_command() is a documented no-op) —
+            # this class tests POSIX login-shell startup semantics that
+            # simply don't apply there. A "bash" may still be on PATH via
+            # Git Bash on Windows runners, but shell_command() ignores it,
+            # so checking for its mere presence isn't the right gate.
+            self.skipTest("POSIX-only: shell_command() doesn't use bash on Windows")
         bash = shutil.which("bash")
         if not bash:
             self.skipTest("bash not available")

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path, PureWindowsPath
@@ -92,6 +94,88 @@ class TestShellCommand(unittest.TestCase):
         exe, args = shell.shell_command()
         self.assertEqual(exe, "/bin/sh")
         self.assertEqual(args, ["-lc"])
+
+
+class TestShellPathRestoration(unittest.TestCase):
+    """`shell_command()` runs install commands through a POSIX *login*
+    shell so the user's package managers are on PATH exactly as in their
+    normal terminal. On Debian/Ubuntu that backfires: the stock
+    ``/etc/profile`` *overwrites* PATH rather than merging into it, and the
+    file most tools (nvm, etc.) actually append PATH in -- ``~/.bashrc`` --
+    starts with ``case $- in *i*) ;; *) return;; esac`` and so is skipped
+    entirely by a non-interactive login shell. A tool `platform.py` already
+    found via `shutil.which()` moments earlier can become invisible to the
+    very install command about to run.
+
+    We can't safely swap in the real `/etc/profile` here, so this
+    simulates the same shape of bug with a throwaway $HOME: a ``.profile``
+    that resets PATH the way Debian's ``/etc/profile`` does and then
+    chains into a ``.bashrc`` carrying the exact real-world nvm-style
+    "bail if not interactive" guard, with the PATH addition living after
+    that guard. `shell_env`/`wrap_command` must restore that addition
+    regardless.
+    """
+
+    def setUp(self):
+        bash = shutil.which("bash")
+        if not bash:
+            self.skipTest("bash not available")
+        self.bash = bash
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        home = Path(self.tmp.name)
+        # Mimic Debian's default ~/.profile chaining into ~/.bashrc, plus
+        # an explicit PATH reset standing in for /etc/profile's overwrite
+        # (the real /etc/profile isn't ours to rewrite in a test).
+        (home / ".profile").write_text(
+            'PATH="/usr/bin:/bin"\n'
+            "export PATH\n"
+            'if [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc"; fi\n'
+        )
+        # The exact convention tools like nvm use: append to PATH at the
+        # bottom of .bashrc, past the stock "not interactive? bail" guard.
+        (home / ".bashrc").write_text(
+            "case $- in\n"
+            "    *i*) ;;\n"
+            "      *) return;;\n"
+            "esac\n"
+            'export PATH="$HOME/late-bashrc-addition:$PATH"\n'
+        )
+        self.marker_dir = str(home / "late-bashrc-addition")
+        self.base_env = {"HOME": str(home), "PATH": f"{self.marker_dir}:/usr/bin:/bin"}
+
+    def _run(self, command, env):
+        exe, args = shell.shell_command()
+        return subprocess.run(
+            [exe, *args, command], env=env, capture_output=True, text=True, timeout=10,
+        )
+
+    def test_plain_login_shell_loses_bashrc_only_path_addition(self):
+        """Demonstrates the bug: without the fix, a PATH entry that only
+        lives past ~/.bashrc's interactive guard doesn't survive a
+        non-interactive login shell, even though it's already in the
+        current process's own (inherited) PATH."""
+        result = self._run('echo "$PATH"', dict(self.base_env))
+        self.assertNotIn(self.marker_dir, result.stdout)
+
+    def test_wrap_command_restores_bashrc_only_path_addition(self):
+        """The fix: shell_env()/wrap_command() carry the current PATH
+        through a side-channel var and restore it after the login shell's
+        own startup files have had their say."""
+        env = shell.shell_env(self.base_env)
+        wrapped = shell.wrap_command('echo "$PATH"')
+        result = self._run(wrapped, env)
+        self.assertIn(self.marker_dir, result.stdout)
+
+    def test_wrap_command_never_introduces_empty_path_component(self):
+        """A missing/blank marker must never turn into a leading `:` --
+        POSIX shells treat an empty PATH component as `.` (cwd), which
+        would be a directory-planted-binary foothold."""
+        env = dict(self.base_env)
+        env.pop("_TUISTORE_LAUNCH_PATH", None)
+        result = self._run(shell.wrap_command('echo "$PATH"'), env)
+        self.assertFalse(result.stdout.startswith(":"))
+        self.assertNotIn("::", result.stdout)
 
 
 class TestWindowsInstallEngine(unittest.TestCase):

--- a/tuistore/__main__.py
+++ b/tuistore/__main__.py
@@ -28,13 +28,15 @@ import shutil
 import subprocess
 import sys
 
-from tuistore.shell import shell_command
+from tuistore.shell import shell_command, shell_env, wrap_command
 
 
 def _run(cmd: str) -> int:
     print(f"$ {cmd}")
     shell, shell_args = shell_command()
-    return subprocess.run([shell, *shell_args, cmd]).returncode
+    return subprocess.run(
+        [shell, *shell_args, wrap_command(cmd)], env=shell_env()
+    ).returncode
 
 
 def _confirm(prompt: str, assume_yes: bool) -> bool:

--- a/tuistore/installer.py
+++ b/tuistore/installer.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from typing import AsyncIterator, Iterable
 
 from .platform import Env
-from .shell import shell_command
+from .shell import shell_command, shell_env, wrap_command
 
 # ── kind metadata ──────────────────────────────────────────────────────────
 # kind -> (label, preference[lower=better], requires, os allow, family allow)
@@ -361,13 +361,16 @@ def best(methods: Iterable[Method], env: Env) -> Method | None:
 async def run_stream(command: str) -> AsyncIterator[tuple[str, str]]:
     """Execute `command` in a login shell, yielding ("out", line) as it runs
     and finally ("exit", returncode). A login shell is used so the user's
-    package managers are on PATH exactly as in their normal terminal."""
+    package managers are on PATH exactly as in their normal terminal; PATH
+    is additionally restored via `wrap_command`/`shell_env` in case the
+    login shell's own startup files reset it (see `shell.shell_env`)."""
     shell, shell_args = shell_command()
     try:
         proc = await asyncio.create_subprocess_exec(
-            shell, *shell_args, command,
+            shell, *shell_args, wrap_command(command),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            env=shell_env(),
         )
     except Exception as e:  # pragma: no cover - shell missing is pathological
         yield ("out", f"could not start shell: {e}")

--- a/tuistore/shell.py
+++ b/tuistore/shell.py
@@ -7,8 +7,15 @@ identically on Windows, macOS, and Linux.
 
 from __future__ import annotations
 
+import os
 import shutil
 import sys
+
+# Env-var name used to carry *this* process's PATH through a subprocess's
+# login-shell startup files (see `shell_env` / `wrap_command` below). Chosen
+# to be distinctive enough that it won't collide with anything a user's own
+# shell config sets.
+_PATH_MARKER = "_TUISTORE_LAUNCH_PATH"
 
 
 def shell_command() -> tuple[str, list[str]]:
@@ -17,6 +24,10 @@ def shell_command() -> tuple[str, list[str]]:
 
     On Windows we prefer PowerShell Core, then Windows PowerShell, then
     cmd.exe. On Unix we use a POSIX login shell (bash, zsh, or /bin/sh).
+
+    Callers should run the returned command through `wrap_command` and pass
+    `shell_env()` as the subprocess environment — see those functions for
+    why a plain login shell isn't sufficient on its own.
     """
     if sys.platform == "win32":
         pwsh = shutil.which("pwsh") or shutil.which("powershell")
@@ -26,3 +37,40 @@ def shell_command() -> tuple[str, list[str]]:
         return "cmd.exe", ["/c"]
     shell = shutil.which("bash") or shutil.which("zsh") or "/bin/sh"
     return shell, ["-lc"]
+
+
+def shell_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Environment to run a `shell_command()` subprocess in.
+
+    A login shell re-runs the system/user startup files (``/etc/profile``,
+    ``~/.profile``, …) before the actual command executes. On Debian and
+    Ubuntu, the stock ``/etc/profile`` *overwrites* PATH outright rather
+    than merging into it, and the file most tools actually append PATH to
+    — ``~/.bashrc``, the exact convention nvm and friends use — starts with
+    ``case $- in *i*) ;; *) return;; esac`` and so is skipped entirely by a
+    non-interactive login shell. Net effect: a tool this process can
+    already find (because *our* PATH has it) can become invisible to the
+    very install command we're about to run, even though nothing about the
+    user's machine actually changed.
+
+    We smuggle the current PATH through under a differently-named variable
+    that those startup files won't touch, so `wrap_command` can restore it
+    no matter what the login shell's own startup did or didn't do.
+    """
+    env = dict(base_env if base_env is not None else os.environ)
+    env[_PATH_MARKER] = env.get("PATH", "")
+    return env
+
+
+def wrap_command(command: str) -> str:
+    """Prefix `command` so PATH entries visible to *this* process stay
+    visible even if the subprocess's login shell resets PATH first.
+
+    Guarded on a non-empty check so a missing/blank marker (e.g. `command`
+    run outside of `shell_env()`) can never introduce an empty PATH
+    component — POSIX shells treat an empty PATH entry as `.` (cwd), which
+    would be a foothold for a directory-planted-binary attack.
+    """
+    if sys.platform == "win32":
+        return command
+    return f'if [ -n "${_PATH_MARKER}" ]; then PATH="${_PATH_MARKER}:$PATH"; fi; {command}'


### PR DESCRIPTION
## The bug

`shell.py`'s `shell_command()` runs every install command through a POSIX **login** shell (`bash`/`zsh -lc`), specifically so package managers show up on PATH exactly as they would in the user's own terminal (see the docstring on `installer.run_stream`).

On Debian and Ubuntu that backfires:

- The stock `/etc/profile` **overwrites** PATH (`PATH="/usr/local/bin:/usr/bin:/bin:..."; export PATH`) rather than merging into it.
- The file most tools actually append PATH to — `~/.bashrc`, the exact convention `nvm` (and friends) use — opens with the standard guard:
  ```sh
  case $- in
      *i*) ;;
        *) return;;
  esac
  ```
  which bails out immediately for any **non-interactive** shell, including a non-interactive login shell (`bash -lc '...'`). So `~/.bashrc`'s PATH additions never run.

Net effect: a tool that `platform.py`'s `shutil.which()` probe *just* confirmed is on PATH (because that probe runs inside this already-fully-initialized process) can silently vanish by the time the actual install command runs in its own subprocess — install/uninstall/update commands can fail with "command not found" for tools tuistore itself reported as available moments earlier.

This is Linux-specific in practice: macOS's `/etc/profile` calls `path_helper`, which *merges* into the inherited PATH rather than overwriting it, so the same subprocess re-invocation doesn't lose anything there.

## Fixes considered and rejected

I verified both flag-only fixes suggested as candidates actually make things worse, not better (repro commands + output in the PR discussion if useful):

- **Interactive shell (`-i`, or `-lic`)**: does make bash read past `~/.bashrc`'s guard, since `$-` now contains `i`. But an interactive bash always tries to grab job control, and when there's no controlling terminal (the normal case for a subprocess with piped stdio) it unconditionally prints `bash: no job control in this shell` to stderr on *every single invocation*, on *every platform* — this gets merged into the install-log stream that's shown to the user (`stderr=STDOUT` in `run_stream`). That's a louder, universal regression traded for a narrower, Linux-only one.
- **Explicitly `source ~/.bashrc` after the login-shell chain**: doesn't help. The guard checks `$-`, and sourcing a file doesn't change the shell's own interactive/non-interactive flag, so the guarded lines still never execute.

## The fix

Instead of changing shell flags, `shell.py` now carries the *current process's* PATH — the one `platform.py`'s probe already trusted — through the subprocess via a differently-named environment variable (`_TUISTORE_LAUNCH_PATH`) that the login shell's startup files won't touch, and restores it with a small command prefix that runs *after* all of the shell's own startup files, regardless of what they did or didn't do to PATH:

```python
def wrap_command(command: str) -> str:
    return f'if [ -n "${_PATH_MARKER}" ]; then PATH="${_PATH_MARKER}:$PATH"; fi; {command}'
```

- `shell_env()` sets the marker on the subprocess environment.
- `wrap_command()` consumes it, guarded so a missing/blank marker can never introduce a leading empty PATH component (POSIX shells treat that as `.`/cwd — a directory-planted-binary foothold).
- Both call sites (`installer.run_stream` and `__main__._run`) now route through `shell_env()`/`wrap_command()`.
- The original PATH is prepended (not appended), so anything this process could already resolve keeps resolving exactly as before; the login shell's own PATH is still consulted as a fallback for anything new it might legitimately add.
- No behavior change on Windows (`wrap_command` is a no-op there).

## Testing

Added `tests/test_windows.py::TestShellPathRestoration`, which builds a throwaway `$HOME` with a `.profile` that resets PATH (standing in for Debian's `/etc/profile`, which isn't ours to rewrite in a test) and chains into a `.bashrc` carrying the *real* interactive-only guard, then drives a real `bash` subprocess through it to demonstrate both:
- the bug (`test_plain_login_shell_loses_bashrc_only_path_addition`), and
- the fix (`test_wrap_command_restores_bashrc_only_path_addition`), plus
- the empty-PATH-component safety guard (`test_wrap_command_never_introduces_empty_path_component`).

Full suite passes:

```
Ran 26 tests in 0.690s

OK
```

Also confirmed all top-level modules still import cleanly:
```
uv run python -c "import tuistore.app, tuistore.__main__, tuistore.installed, tuistore.catalog, tuistore.installer, tuistore.scrape, tuistore.github, tuistore.platform"
```