### PR TITLE
aur: pin Python runtime deps so package() never hits the network

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -8,18 +8,123 @@ url="https://github.com/Gheat1/tuistore"
 license=('GPL-3.0-or-later')
 depends=('python')
 makedepends=('uv')
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Gheat1/tuistore/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('b2be71b0c34b8a3b3dd569a48c5b4f968c0d932aa0aaf01a33c8b3e37b75012b')
 
 # tuistore and ricekit are both on PyPI now, but neither is packaged for
 # Arch — a private venv is the simplest correct way to satisfy the
 # dependency without re-packaging ricekit separately.
+#
+# Every runtime dependency (tuistore's direct PyPI deps plus their full
+# transitive closure) is vendored below as a pinned, pure-Python wheel so
+# that package() never has to reach PyPI. This is required for makepkg's
+# integrity/offline guarantees to actually hold — a clean chroot build
+# (makechrootpkg) or any CI/air-gapped build host has no network access,
+# and pacman's rebuild reproducibility depends on every byte that ends up
+# in the package being covered by source/sha256sums.
+#
+# The set below was resolved against pyproject.toml's dependency ranges
+# ("textual>=1.0", "httpx>=0.27", "ricekit>=0.2.0" as of pkgver=0.4.3) with:
+#   uv pip compile <(printf 'textual>=1.0\nhttpx>=0.27\nricekit>=0.2.0\n') \
+#       --python-version 3.11
+# and cross-checked at both 3.11 and 3.13 to make sure no version-gated
+# marker (e.g. anyio's exceptiongroup backport) silently changes the
+# closure on a different build host's Python minor version — none of the
+# packages below are needed on any 3.11+ interpreter.
+#
+# Re-resolve and re-pin this whole list on every dependency bump (new
+# tuistore release, ricekit release, or a transitive dep major bump).
+source=(
+    "$pkgname-$pkgver.tar.gz::https://github.com/Gheat1/tuistore/archive/refs/tags/v$pkgver.tar.gz"
+
+    # --- runtime deps (textual, httpx, ricekit) + full transitive closure ---
+    "anyio-4.14.2-py3-none-any.whl::https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl"
+    "certifi-2026.6.17-py3-none-any.whl::https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl"
+    "h11-0.16.0-py3-none-any.whl::https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl"
+    "httpcore-1.0.9-py3-none-any.whl::https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl"
+    "httpx-0.28.1-py3-none-any.whl::https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl"
+    "idna-3.18-py3-none-any.whl::https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl"
+    "linkify_it_py-2.1.0-py3-none-any.whl::https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl"
+    "markdown_it_py-4.2.0-py3-none-any.whl::https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl"
+    "mdit_py_plugins-0.6.1-py3-none-any.whl::https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl"
+    "mdurl-0.1.2-py3-none-any.whl::https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+    "platformdirs-4.10.1-py3-none-any.whl::https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl"
+    "pygments-2.20.0-py3-none-any.whl::https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl"
+    "ricekit-0.2.0-py3-none-any.whl::https://files.pythonhosted.org/packages/e2/06/255a4272be351beb3ca4c575bffecd48efb160005abe9638117dbcc88f02/ricekit-0.2.0-py3-none-any.whl"
+    "rich-15.0.0-py3-none-any.whl::https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl"
+    "textual-8.2.8-py3-none-any.whl::https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl"
+    "typing_extensions-4.16.0-py3-none-any.whl::https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl"
+    "uc_micro_py-2.0.0-py3-none-any.whl::https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl"
+
+    # --- build-time only: PEP 517 backend for tuistore's own setuptools
+    #     build. Installed and used with --no-build-isolation, then
+    #     uninstalled again before the venv is staged into the package. ---
+    "setuptools-83.0.0-py3-none-any.whl::https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl"
+)
+sha256sums=('b2be71b0c34b8a3b3dd569a48c5b4f968c0d932aa0aaf01a33c8b3e37b75012b'
+            '9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494'
+            '2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db'
+            '63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86'
+            '2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55'
+            'd909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad'
+            '7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2'
+            '0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e'
+            '9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a'
+            '214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d'
+            '84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8'
+            '0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443'
+            '81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176'
+            'e0fb551bd69d6fc44b800a1ce82f4f5eb53cc68e3f44beaaf0b0816bdc5c09a6'
+            '33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb'
+            '267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a'
+            '481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8'
+            '3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c'
+            '29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3')
+
+# wheels are zip archives but makepkg only auto-extracts recognized
+# archive extensions (.tar.*, .zip, ...) — .whl isn't one of them, so
+# these are already left untouched. Listed explicitly for clarity and to
+# pin behavior if that extension list ever changes upstream.
+noextract=(
+    'anyio-4.14.2-py3-none-any.whl'
+    'certifi-2026.6.17-py3-none-any.whl'
+    'h11-0.16.0-py3-none-any.whl'
+    'httpcore-1.0.9-py3-none-any.whl'
+    'httpx-0.28.1-py3-none-any.whl'
+    'idna-3.18-py3-none-any.whl'
+    'linkify_it_py-2.1.0-py3-none-any.whl'
+    'markdown_it_py-4.2.0-py3-none-any.whl'
+    'mdit_py_plugins-0.6.1-py3-none-any.whl'
+    'mdurl-0.1.2-py3-none-any.whl'
+    'platformdirs-4.10.1-py3-none-any.whl'
+    'pygments-2.20.0-py3-none-any.whl'
+    'ricekit-0.2.0-py3-none-any.whl'
+    'rich-15.0.0-py3-none-any.whl'
+    'textual-8.2.8-py3-none-any.whl'
+    'typing_extensions-4.16.0-py3-none-any.whl'
+    'uc_micro_py-2.0.0-py3-none-any.whl'
+    'setuptools-83.0.0-py3-none-any.whl'
+)
+
 package() {
     cd "$pkgname-$pkgver"
 
     install -d "$pkgdir/opt/$pkgname"
     uv venv --python python3 "$pkgdir/opt/$pkgname/venv"
-    uv pip install --python "$pkgdir/opt/$pkgname/venv/bin/python" .
+    venvpy="$pkgdir/opt/$pkgname/venv/bin/python"
+
+    # Fully offline install: --no-index/--find-links restrict resolution
+    # to the pinned wheels staged in $srcdir by source[] above, so this
+    # never touches the network, matching the integrity guarantee that
+    # sha256sums is supposed to provide.
+    #
+    # setuptools has to be installed into the venv first (rather than
+    # just sitting in $srcdir) because --no-build-isolation makes tuistore's
+    # own setuptools.build_meta backend run in-process against whatever
+    # python it's given — it needs to already be importable there.
+    uv pip install --python "$venvpy" --no-index --find-links "$srcdir" \
+        setuptools
+    uv pip install --python "$venvpy" --no-index --find-links "$srcdir" \
+        --no-build-isolation .
+    uv pip uninstall --python "$venvpy" setuptools
 
     # invoke the venv's python directly (-m) rather than relying on the
     # auto-generated entry-point script, whose shebang bakes in the

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,123 @@
+"""Guards against the AUR PKGBUILD silently depending on network access.
+
+package() vendors tuistore into a private venv via `uv pip install`. If that
+install isn't pinned to files already listed in source[]/sha256sums[] (via
+--no-index/--find-links), makepkg's integrity/offline guarantees are a lie:
+the build reaches out to PyPI for tuistore's Python dependencies (textual,
+httpx, ricekit, and their transitive closure) at package-build time, which
+hard-fails in a clean chroot build or any network-isolated CI/build host.
+
+These tests parse the PKGBUILD text directly (no bash execution, no
+makepkg/network needed) so they run anywhere `unittest discover` does.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+PKGBUILD_PATH = Path(__file__).resolve().parent.parent / "packaging" / "aur" / "PKGBUILD"
+
+
+def _read_pkgbuild() -> str:
+    return PKGBUILD_PATH.read_text()
+
+
+def _strip_comments(text: str) -> str:
+    """Drop `# ...` comment text so it can't hide a stray `(`/`)` from the
+    array-boundary scan below. None of this PKGBUILD's quoted values (source
+    URLs, filenames, the pkgdesc string) contain a literal '#', so a plain
+    per-line truncation at the first '#' is safe here.
+    """
+    return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+
+
+def _bash_array(text: str, name: str) -> list[str]:
+    """Pull the raw entries out of a `name=(...)` bash array in PKGBUILD text.
+
+    Handles both the single-line form (`name=("foo")`) and the multi-line
+    form (`name=(\n    "foo"\n    "bar"\n)`) — entries here never contain a
+    literal `)`, so stopping at the first closing paren is safe either way,
+    as long as comments (which can legitimately contain parens) are removed
+    first.
+    """
+    text = _strip_comments(text)
+    match = re.search(rf"^{re.escape(name)}=\((.*?)\)", text, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise AssertionError(f"could not find {name}=(...) array in PKGBUILD")
+    body = match.group(1)
+    # entries are quoted strings, one (or more) per line
+    return re.findall(r"""(['"])(.*?)\1""", body, re.DOTALL)
+
+
+def _package_function(text: str) -> str:
+    match = re.search(r"^package\(\)\s*\{(.*)\}\s*$", text, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise AssertionError("could not find package() function in PKGBUILD")
+    return match.group(1)
+
+
+class PkgbuildOfflineIntegrityTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = _read_pkgbuild()
+
+    def test_source_and_sha256sums_arrays_are_equal_length(self) -> None:
+        sources = _bash_array(self.text, "source")
+        sums = _bash_array(self.text, "sha256sums")
+        self.assertEqual(
+            len(sources),
+            len(sums),
+            "source[] and sha256sums[] must have one checksum per source entry",
+        )
+        self.assertGreater(len(sources), 0)
+
+    def test_python_runtime_dependencies_are_vendored_as_pinned_sources(self) -> None:
+        # tuistore's direct PyPI dependencies (see pyproject.toml) plus enough
+        # of their transitive closure to prove this isn't just the app's own
+        # tarball. If package() ever goes back to resolving these from PyPI
+        # at build time, this list won't appear in source[] and this fails.
+        required_deps = {
+            "textual",
+            "httpx",
+            "ricekit",
+            "rich",
+            "anyio",
+            "certifi",
+            "httpcore",
+            "idna",
+        }
+        sources = [entry for _, entry in _bash_array(self.text, "source")]
+        source_blob = "\n".join(sources).lower()
+
+        missing = {dep for dep in required_deps if dep.replace("-", "_") not in source_blob.replace("-", "_")}
+        self.assertFalse(
+            missing,
+            f"these runtime dependencies have no pinned source[] entry: {sorted(missing)}",
+        )
+
+    def test_package_function_never_installs_from_network(self) -> None:
+        package_body = _package_function(self.text)
+
+        install_lines = [
+            line
+            for line in package_body.splitlines()
+            if re.search(r"\buv\s+pip\s+install\b", line)
+        ]
+        self.assertTrue(install_lines, "package() should install the app via `uv pip install`")
+
+        for line in install_lines:
+            self.assertIn(
+                "--no-index",
+                line,
+                f"`uv pip install` in package() must pass --no-index so it can "
+                f"never silently reach PyPI at build time, got: {line!r}",
+            )
+            self.assertIn(
+                "--find-links",
+                line,
+                f"`uv pip install` in package() must pass --find-links pointing "
+                f"at the pinned sources, got: {line!r}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`packaging/aur/PKGBUILD`'s `package()` builds tuistore's private venv with:

```sh
uv pip install --python "$pkgdir/opt/$pkgname/venv/bin/python" .
```

`uv pip install .` resolves tuistore's PyPI-only dependencies (`textual`,
`httpx`, `ricekit`) and their *full transitive closure* — 14 more packages
(`rich`, `pygments`, `markdown-it-py`, `mdit-py-plugins`, `mdurl`,
`linkify-it-py`, `uc-micro-py`, `platformdirs`, `typing-extensions`,
`anyio`, `certifi`, `httpcore`, `idna`, `h11`) — by hitting PyPI at
**build time**. None of those files were ever listed in `source[]` /
`sha256sums[]`, so makepkg's integrity/offline guarantees didn't actually
cover the bulk of what ends up in the package, and the build hard-fails
with no network available — exactly the situation in Arch's recommended
clean-chroot build workflow (`makechrootpkg`) or any CI/air-gapped build
host.

## The fix

- Resolved the real dependency closure against `pyproject.toml`'s ranges
  (`textual>=1.0`, `httpx>=0.27`, `ricekit>=0.2.0`, matching the `v0.4.3`
  tag this PKGBUILD is pinned to) with `uv pip compile`, cross-checked at
  both Python 3.11 and 3.13 so no version-gated marker (e.g. anyio's
  `exceptiongroup` backport) changes the closure on a different build
  host — none of the 17 resolved packages differ across supported Python
  versions.
- Every one of those 17 packages is pure Python, so each is vendored as
  its pinned `py3-none-any` wheel in `source[]`, with a matching
  `sha256sums[]` entry — no compiler/build toolchain needed for any of
  them, so `arch=('any')` stays correct.
- `package()` now installs everything with
  `--no-index --find-links "$srcdir"`, restricting resolution to exactly
  those pinned, checksummed files. It can no longer reach PyPI, silently
  or otherwise.
- `setuptools` is vendored the same way to satisfy tuistore's own PEP 517
  `setuptools.build_meta` backend (needed because `--no-build-isolation`
  runs the backend in-process against the given interpreter, so it must
  already be importable there), then `uv pip uninstall`'d again so it
  doesn't linger unused in the shipped venv.
- `.whl` files aren't auto-extracted by makepkg (not a recognized archive
  extension), so they're also listed in `noextract[]` for clarity/safety
  in case that ever changes upstream.

## Verification

- `makepkg --verifysource` (installed via `brew install makepkg`, which
  is genuinely upstream Arch's `makepkg`/pacman tooling packaged for
  macOS) passes: all 19 sources — the tuistore tarball plus 18 pinned
  wheels — validate against `sha256sums[]`.
- Manually exercised the exact same `uv` command sequence used in
  `package()` (`uv venv`, install `setuptools`, then
  `uv pip install --no-index --find-links ... --no-build-isolation .`,
  then uninstall `setuptools`) against a local venv with network access
  cut off via `--no-index`, and confirmed the resulting venv actually
  runs (`python -m tuistore --version` / `--help` both work).
- Added `tests/test_packaging.py`, which parses the PKGBUILD directly
  (no bash/makepkg execution needed) and asserts: `source[]` and
  `sha256sums[]` have matching lengths, every runtime dependency has a
  pinned `source[]` entry, and every `uv pip install` in `package()`
  passes both `--no-index` and `--find-links`. Confirmed it fails against
  the pre-fix PKGBUILD on the two assertions that matter (missing pinned
  deps, unpinned network install) and passes against the fix.
- Full suite: `uv run python -m unittest discover tests -v` → **26
  tests, OK** (23 existing + 3 new).
- `uv run python -c "import tuistore.app, tuistore.__main__, ..."` for
  all listed modules → clean exit.

## Note

`pkgver` stays at `0.4.3` (unchanged) to keep this change scoped to the
packaging bug — upstream now has a newer `v0.4.5` tag, but bumping
`pkgver`/re-pinning for a version bump is a separate concern from fixing
the offline-build guarantee, and is called out in the PKGBUILD's comment
so the next version bump re-resolves and re-pins this same list.