### PR TITLE
Fix package-name parsing corrupting installs and lifecycle commands

### DIFF
--- a/tests/test_installed.py
+++ b/tests/test_installed.py
@@ -168,6 +168,22 @@ class TestManagerAwarePackageParsing(unittest.TestCase):
             "posting",
         )
 
+    def test_other_value_flags_are_not_targets_either(self):
+        # _VALUE_FLAGS only lists the flags plausible in a real README, not
+        # every pip/uv flag — these are the ones outside --python that would
+        # otherwise reproduce the same "flag value mistaken for the package"
+        # bug this PR fixes.
+        cases = [
+            ("pip", "pip install --target /custom/dir mypackage", "mypackage"),
+            ("pip", "pip install -r requirements.txt somepkg", "somepkg"),
+            ("pip", "pip install --prefix /usr/local mypackage", "mypackage"),
+            ("uv", "uv tool install --python-preference only-managed mypackage", "mypackage"),
+            ("uv", "uv tool install --resolution lowest mypackage", "mypackage"),
+        ]
+        for kind, command, expected in cases:
+            with self.subTest(command=command):
+                self.assertEqual(pkg_from_command(kind, command), expected)
+
     def test_extras_are_kept_for_install_and_stripped_for_lifecycle(self):
         command = 'pip install "yt-dlp[default]"'
         self.assertEqual(_extract_target("pip", command), "yt-dlp[default]")

--- a/tests/test_installed.py
+++ b/tests/test_installed.py
@@ -4,9 +4,11 @@ from pathlib import Path
 from unittest import mock
 
 from tuistore.installed import (
+    _extract_target,
     load_ledger,
     pkg_from_command,
     record_install,
+    status,
     system_upgrade_command,
     uninstall_command,
     update_command,
@@ -133,6 +135,119 @@ class TestPkgFromCommandRegularPackages(unittest.TestCase):
     def test_brew_tap_qualified_formula(self):
         self.assertEqual(
             pkg_from_command("brew", "brew install user/tap/formula"), "formula"
+        )
+
+
+class TestManagerAwarePackageParsing(unittest.TestCase):
+    def test_install_verb_anchors_and_aliases(self):
+        cases = [
+            ("eopkg", "eopkg install foo", "foo"),
+            ("eopkg", "eopkg it foo", "foo"),
+            ("nix", "nix-env -i bat", "bat"),
+            ("brew", "brew tap user/tap && brew install cwal", "cwal"),
+            ("zypper", "zypper ref && zypper in lazygit", "lazygit"),
+            ("apt", "sudo apt update; sudo apt install bat", "bat"),
+        ]
+        for kind, command, expected in cases:
+            with self.subTest(command=command):
+                self.assertEqual(pkg_from_command(kind, command), expected)
+
+    def test_wrappers_and_assignments_before_install_verb(self):
+        cases = [
+            ("brew", "sudo arch -arm64 brew install yq", "yq"),
+            ("cargo", "FOO='-C bar' cargo install yq --locked", "yq"),
+            ("go", "env GOFLAGS=-mod=mod go install github.com/mikefarah/yq/v4@latest", "yq"),
+        ]
+        for kind, command, expected in cases:
+            with self.subTest(command=command):
+                self.assertEqual(pkg_from_command(kind, command), expected)
+
+    def test_python_value_flags_are_not_targets(self):
+        self.assertEqual(
+            pkg_from_command("uv", "uv tool install --python 3.13 posting"),
+            "posting",
+        )
+
+    def test_extras_are_kept_for_install_and_stripped_for_lifecycle(self):
+        command = 'pip install "yt-dlp[default]"'
+        self.assertEqual(_extract_target("pip", command), "yt-dlp[default]")
+        self.assertEqual(pkg_from_command("pip", command), "yt-dlp")
+
+
+class TestLifecycleSafetyAndRepair(unittest.TestCase):
+    def test_eopkg_lifecycle_targets_package(self):
+        for command in ("eopkg install foo", "eopkg it foo"):
+            rec = {"kind": "eopkg", "command": command, "pkg": "eopkg"}
+            with self.subTest(command=command):
+                self.assertEqual(uninstall_command(rec), "sudo eopkg remove foo")
+                self.assertEqual(update_command(rec), "sudo eopkg upgrade foo")
+
+    def test_lifecycle_rederives_and_repairs_corrupt_pkg(self):
+        cases = [
+            (
+                {"kind": "uv", "command": "uv tool install --python 3.11 thefuck", "pkg": "3.11"},
+                "uv tool uninstall thefuck",
+                "uv tool upgrade thefuck",
+            ),
+            (
+                {"kind": "uv", "command": 'uv tool install "yt-dlp[default]"', "pkg": '"yt-dlp[default]"'},
+                "uv tool uninstall yt-dlp",
+                "uv tool upgrade yt-dlp",
+            ),
+        ]
+        for rec, uninstall, update in cases:
+            with self.subTest(command=rec["command"]):
+                self.assertEqual(uninstall_command(rec), uninstall)
+                self.assertEqual(update_command(rec), update)
+
+    def test_commandless_record_falls_back_to_pkg(self):
+        rec = {"kind": "uv", "pkg": "ruff"}
+        self.assertEqual(uninstall_command(rec), "uv tool uninstall ruff")
+        self.assertEqual(update_command(rec), "uv tool upgrade ruff")
+
+    def test_legit_package_punctuation_renders_unchanged(self):
+        cases = [
+            ("npm", "npm install -g @openai/codex", "npm uninstall -g @openai/codex", "npm install -g @openai/codex@latest"),
+            ("nix", "nix profile install nixpkgs#cwal", "nix profile remove nixpkgs#cwal", "nix profile upgrade nixpkgs#cwal"),
+            ("emerge", "emerge dev-vcs/gitui::dm9pZCAq", "sudo emerge --unmerge dev-vcs/gitui::dm9pZCAq", "sudo emerge --update dev-vcs/gitui::dm9pZCAq"),
+        ]
+        for kind, command, uninstall, update in cases:
+            rec = {"kind": kind, "command": command, "pkg": "corrupt"}
+            with self.subTest(command=command):
+                self.assertEqual(uninstall_command(rec), uninstall)
+                self.assertEqual(update_command(rec), update)
+
+    def test_shell_metacharacters_are_rejected(self):
+        commands = [
+            "pip install '; rm -rf ~'",
+            "pip install '$(touch /tmp/tuistore-pwn)'",
+            "pip install 'unterminated",
+        ]
+        for command in commands:
+            rec = {"kind": "pip", "command": command, "pkg": "bad;pkg"}
+            with self.subTest(command=command):
+                self.assertIsNone(pkg_from_command("pip", command))
+                self.assertIsNone(uninstall_command(rec))
+                self.assertIsNone(update_command(rec))
+
+    def test_hostile_commandless_pkg_is_rejected(self):
+        rec = {"kind": "apt", "pkg": "foo;rm"}
+        self.assertIsNone(uninstall_command(rec))
+        self.assertIsNone(update_command(rec))
+
+    def test_go_bin_path_traversal_and_metacharacters_are_rejected(self):
+        command = "go install github.com/owner/repo/cmd/tool@latest"
+        for binn in ("x/../../victim", "tool;rm"):
+            rec = {"kind": "go", "command": command, "pkg": "tool", "bin": binn}
+            with self.subTest(bin=binn):
+                self.assertIsNone(uninstall_command(rec))
+
+    def test_status_compares_extras_method_with_bare_installed_name(self):
+        methods = [Method(kind="pip", command='pip install "yt-dlp[default]"')]
+        self.assertEqual(
+            status("yt-dlp/yt-dlp", "yt-dlp", methods, {},
+                   bins=frozenset(), pkgs={"pip": {"yt-dlp"}}),
+            "present",
         )
 
 

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,6 +1,8 @@
 import unittest
+from types import SimpleNamespace
 
-from tuistore.catalog import Entry, _prefer_uv
+from tuistore.app import StoreApp
+from tuistore.catalog import Entry, _bundled_text, _parse, _prefer_uv
 from tuistore.installed import pkg_from_command, uninstall_command, update_command
 from tuistore.installer import KINDS, classify, force_variant, make
 from tuistore.platform import Env
@@ -107,6 +109,78 @@ class TestClassifyUvPip(unittest.TestCase):
         uv_methods = [m for m in entry.methods if m.kind == "uv"]
         self.assertEqual(len(uv_methods), 1)
         self.assertEqual(uv_methods[0].command, "uv tool install ruff")
+
+
+class TestPackageParsingPipeline(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        raw = _bundled_text()
+        assert raw is not None
+        cls.entries = {entry.name: entry for entry in _parse(raw).entries}
+
+    def test_posting_preserves_pinned_uv_install_and_lifecycle_target(self):
+        method = self.entries["posting"].methods[0]
+        self.assertEqual(method.command, "uv tool install --python 3.13 posting")
+        rec = {"kind": method.kind, "command": method.command, "pkg": "3.13"}
+        self.assertEqual(uninstall_command(rec), "uv tool uninstall posting")
+        self.assertEqual(update_command(rec), "uv tool upgrade posting")
+
+    def test_thefuck_quirk_keeps_lifecycle_target(self):
+        method = self.entries["thefuck"].methods[0]
+        self.assertEqual(method.command, "uv tool install --python 3.11 thefuck")
+        rec = {"kind": method.kind, "command": method.command, "pkg": "3.11"}
+        self.assertEqual(uninstall_command(rec), "uv tool uninstall thefuck")
+        self.assertEqual(update_command(rec), "uv tool upgrade thefuck")
+
+    def test_yt_dlp_keeps_quoted_extras_and_winner_metadata(self):
+        method = self.entries["yt-dlp"].methods[0]
+        self.assertEqual(method.command, "uv tool install 'yt-dlp[default]'")
+        self.assertEqual(method.source, "readme")
+        self.assertEqual(method.note, "from README")
+        self.assertEqual(method.requires, ["uv"])
+        rec = {"kind": method.kind, "command": method.command, "pkg": '"yt-dlp[default]"'}
+        self.assertEqual(uninstall_command(rec), "uv tool uninstall yt-dlp")
+        self.assertEqual(update_command(rec), "uv tool upgrade yt-dlp")
+
+    def test_manage_candidates_compares_extras_as_bare_name(self):
+        entry = Entry(name="yt-dlp", url="https://github.com/yt-dlp/yt-dlp")
+        entry.methods = [make("pip", 'pip install "yt-dlp[default]"', source="readme")]
+        app = SimpleNamespace(env=Env("linux", "ubuntu", {"debian"}, tools={"pip3"}))
+        self.assertEqual(
+            StoreApp._manage_candidates(app, entry, "update"),
+            [("pip", "python3 -m pip install -U yt-dlp")],
+        )
+
+
+class TestPreferUvIntegrity(unittest.TestCase):
+    def test_uv_winner_object_and_metadata_are_preserved(self):
+        winner = make("uv", "uv tool install --python 3.13 posting", source="readme", note="pinned")
+        winner.os, winner.families = ["linux"], ["debian"]
+        inferred = make("uv", "uv tool install posting", note="guess")
+        entry = Entry(name="posting", url="https://github.com/darrenburns/posting",
+                      methods=[winner, inferred])
+        _prefer_uv(entry)
+        self.assertIs(entry.methods[0], winner)
+        self.assertEqual([m for m in entry.methods if m.kind == "uv"], [winner])
+        self.assertEqual((winner.note, winner.os, winner.families),
+                         ("pinned", ["linux"], ["debian"]))
+
+    def test_pip_winner_translation_uses_uv_requirements_and_metadata(self):
+        winner = make("pip", 'pip install "yt-dlp[default]"', source="readme", note="from README")
+        winner.os, winner.families = ["linux"], ["debian"]
+        entry = Entry(name="yt-dlp", url="https://github.com/yt-dlp/yt-dlp", methods=[winner])
+        _prefer_uv(entry)
+        method = entry.methods[0]
+        self.assertEqual(method.command, "uv tool install 'yt-dlp[default]'")
+        self.assertEqual(method.requires, ["uv"])
+        self.assertEqual((method.source, method.note, method.os, method.families),
+                         ("readme", "from README", ["linux"], ["debian"]))
+
+    def test_invalid_pip_target_is_not_synthesized(self):
+        winner = make("pip", "pip install 'bad;target'", source="readme")
+        entry = Entry(name="bad", url="https://github.com/owner/bad", methods=[winner])
+        _prefer_uv(entry)
+        self.assertEqual(entry.methods, [winner])
 
 
 class ClassifyScriptTest(unittest.TestCase):

--- a/tuistore/catalog.py
+++ b/tuistore/catalog.py
@@ -9,6 +9,7 @@ scoring one entry is a handful of string ops.
 from __future__ import annotations
 
 import json
+import shlex
 from dataclasses import dataclass, field
 from functools import lru_cache
 from importlib import resources
@@ -205,21 +206,31 @@ def _prefer_uv(entry: Entry) -> None:
     method names a package, canonicalize a single uv method that inherits the
     most-trusted package name + source — so uv wins over pip/pipx/brew and uses
     the README-verified package name rather than a guess."""
-    from .installed import pkg_from_command
+    from .installed import _extract_target
     from .installer import make
 
-    best_src, best_pkg = None, None
-    for m in entry.methods:
-        if m.kind in ("uv", "uv-pip", "pipx", "pip"):
-            pkg = pkg_from_command(m.kind, m.command)
-            if pkg and (best_src is None
-                        or _SRC_ORDER.get(m.source, 9) < _SRC_ORDER.get(best_src, 9)):
-                best_src, best_pkg = m.source, pkg
-    if not best_pkg:
+    winner = None
+    for method in entry.methods:
+        if (method.kind in ("uv", "uv-pip", "pipx", "pip")
+                and (winner is None
+                     or _SRC_ORDER.get(method.source, 9)
+                     < _SRC_ORDER.get(winner.source, 9))):
+            winner = method
+    if not winner:
+        return
+    target = _extract_target(winner.kind, winner.command)
+    if not target:
         return
     entry.methods = [m for m in entry.methods if m.kind != "uv"]
-    entry.methods.insert(0, make("uv", f"uv tool install {best_pkg}",
-                                 source=best_src, note="python tool"))
+    if winner.kind == "uv":
+        entry.methods.insert(0, winner)
+        return
+    # ponytail: POSIX quoting only; add Windows/pwsh quoting when a Windows uv
+    # user actually reports a glob break — no Windows CI to test it against today.
+    uv = make("uv", f"uv tool install {shlex.quote(target)}",
+              source=winner.source, note=winner.note)
+    uv.os, uv.families = winner.os, winner.families
+    entry.methods.insert(0, uv)
 
 
 # ── known-incompatible package/runtime combos ────────────────────────────────
@@ -228,8 +239,7 @@ def _prefer_uv(entry: Entry) -> None:
 # hard-depends on something a later language runtime removed. Rather than
 # guess generically, the exact fix is pinned per package as reports come in.
 # Keyed by "owner/repo" slug -> {kind: replacement command}. Applied AFTER
-# _prefer_uv, since that unconditionally regenerates the uv method's command
-# and would otherwise clobber any fix baked in earlier.
+# _prefer_uv so the pin overrides the selected default method.
 QUIRKS: dict[str, dict[str, str]] = {
     # thefuck 3.32 imports distutils, removed from the stdlib in Python 3.12
     # (see PEP 632, verified empirically: present on 3.11, gone on 3.12+).

--- a/tuistore/installed.py
+++ b/tuistore/installed.py
@@ -14,12 +14,14 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import shlex
 import subprocess
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
 
-from .installer import Method
+from .installer import _CLASSIFY, Method
 from .paths import user_data_dir
 
 LEDGER = user_data_dir() / "installed.json"
@@ -95,6 +97,18 @@ _NOISE = {
 # cargo flags that take a following value — the value is never the crate name
 _CARGO_VALUE_FLAGS = {"--git", "--branch", "--tag", "--rev", "--path", "--version", "--features"}
 
+# Python-manager flags whose following token is a value, not the package.
+_VALUE_FLAGS = {
+    "--python", "--with", "--index", "--index-url", "--extra-index-url",
+    "-c", "--constraint",
+}
+
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9@][A-Za-z0-9@/#:._+-]*$")
+_SAFE_TARGET = re.compile(
+    r"^[A-Za-z0-9@][A-Za-z0-9@/#:._+-]*(?:\[[A-Za-z0-9,._+-]+\])?$"
+)
+_SAFE_BIN = re.compile(r"^[A-Za-z0-9@][A-Za-z0-9._+-]*$")
+
 # pip/uv/pipx VCS install specs (PEP 440 direct references), e.g.
 # "git+https://github.com/owner/repo", "git+ssh://git@host/owner/repo.git@branch"
 _VCS_PREFIXES = ("git+", "hg+", "svn+", "bzr+")
@@ -163,23 +177,49 @@ def _cargo_pkg(command: str) -> str | None:
     return None
 
 
-def pkg_from_command(kind: str, command: str) -> str | None:
-    """Best-effort package / target name from an install command."""
+def _extract_target(kind: str, command: str) -> str | None:
+    """Install target after the recorded manager's install verb.
+
+    Anchoring on installer._CLASSIFY skips wrappers and earlier chained
+    commands without duplicating its shell grammar. The final allowlist is
+    the safety boundary for scraped or malformed command strings.
+    """
     if kind in ("script", "source"):
         return None
+    rx = dict(_CLASSIFY).get(kind)
+    match = rx.search(command) if rx else None
+    args = command[match.end():] if match else command
     if kind in ("cargo", "cargo-binstall"):
-        return _cargo_pkg(command)
-    tokens = command.replace("&&", " ").split()
-    cands = [
-        t for t in tokens
-        if t.lower() not in _NOISE and not t.startswith("-")
-    ]
+        target = _cargo_pkg(args)
+        return target if target and _SAFE_TARGET.fullmatch(target) else None
+    try:
+        tokens = shlex.split(args)
+    except ValueError:
+        tokens = args.split()
+    cands = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if kind in {"uv", "uv-pip", "pipx", "pip"} and token in _VALUE_FLAGS:
+            skip_next = True
+            continue
+        if token.lower() not in _NOISE and not token.startswith("-"):
+            cands.append(token)
     if kind == "go":
         # go install github.com/owner/repo/cmd/tool@latest -> "tool"
         for t in cands:
             if "/" in t or "@" in t:
-                return _strip_version_pin(t).rstrip("/").split("/")[-1]
-        return _strip_version_pin(cands[-1]) if cands else None
+                parts = _strip_version_pin(t).rstrip("/").split("/")
+                target = parts[-1]
+                # ponytail: Go /vN suffix only; remote metadata is needed for
+                # other module-path/binary mismatches.
+                if re.fullmatch(r"v\d+", target) and len(parts) > 1:
+                    target = parts[-2]
+                return target if _SAFE_TARGET.fullmatch(target) else None
+        target = _strip_version_pin(cands[-1]) if cands else None
+        return target if target and _SAFE_TARGET.fullmatch(target) else None
     # drop bare URLs and VCS install specs (git+https://..., git+ssh://...)
     # for non-go managers — neither is a valid package name to feed back into
     # an uninstall/upgrade command. A VCS spec still gets a best-effort repo
@@ -190,14 +230,22 @@ def pkg_from_command(kind: str, command: str) -> str | None:
     if not cands:
         for t in urls:
             if t.startswith(_VCS_PREFIXES):
-                return _vcs_repo_name(t)
+                target = _vcs_repo_name(t)
+                return target if target and _SAFE_TARGET.fullmatch(target) else None
         return None
-    pkg = _strip_version_pin(cands[0])
+    target = _strip_version_pin(cands[0])
     # a tap-qualified brew formula (user/tap/formula) installs with the full
     # path but updates/uninstalls with the bare formula name.
-    if kind == "brew" and "/" in pkg:
-        pkg = pkg.split("/")[-1]
-    return pkg
+    if kind == "brew" and "/" in target:
+        target = target.split("/")[-1]
+    return target if _SAFE_TARGET.fullmatch(target) else None
+
+
+def pkg_from_command(kind: str, command: str) -> str | None:
+    """Safe bare package name for lifecycle commands and comparisons."""
+    target = _extract_target(kind, command)
+    pkg = target.partition("[")[0] if target else None
+    return pkg if pkg and _SAFE_NAME.fullmatch(pkg) else None
 
 
 # ── update / uninstall command derivation ───────────────────────────────────
@@ -268,15 +316,21 @@ _UPDATE = {
 
 
 def uninstall_command(rec: dict) -> str | None:
-    kind, pkg, binn = rec.get("kind", ""), rec.get("pkg", ""), rec.get("bin", "")
+    kind = rec.get("kind", "")
+    pkg = pkg_from_command(kind, rec.get("command", "")) or rec.get("pkg", "")
+    binn = rec.get("bin", "") or pkg
     tmpl = _UNINSTALL.get(kind)
-    if not tmpl or not (pkg or binn):
+    if (not tmpl or not pkg or not _SAFE_NAME.fullmatch(pkg)
+            or "{bin}" in tmpl and (not binn or not _SAFE_BIN.fullmatch(binn))):
         return None
-    return tmpl.format(pkg=pkg or binn, bin=binn or pkg)
+    return tmpl.format(pkg=pkg, bin=binn)
 
 
 def update_command(rec: dict) -> str | None:
-    kind, pkg = rec.get("kind", ""), rec.get("pkg", "")
+    kind = rec.get("kind", "")
+    pkg = pkg_from_command(kind, rec.get("command", "")) or rec.get("pkg", "")
+    if not pkg or not _SAFE_NAME.fullmatch(pkg):
+        return None
     if kind == "go":
         # re-run the original `go install …@latest`
         return rec.get("command")

--- a/tuistore/installed.py
+++ b/tuistore/installed.py
@@ -98,9 +98,17 @@ _NOISE = {
 _CARGO_VALUE_FLAGS = {"--git", "--branch", "--tag", "--rev", "--path", "--version", "--features"}
 
 # Python-manager flags whose following token is a value, not the package.
+# Not exhaustive of every pip/uv flag — covers the ones plausible in a
+# README's one-line install instructions. An unlisted value-taking flag
+# still fails safely rather than silently: its value either starts with
+# "/" (a path, e.g. an uncovered --some-dir flag) and is rejected by
+# _SAFE_TARGET, or is itself flag-shaped and already excluded — the real
+# risk this list exists to close is a flag value that *looks* like a
+# package name (e.g. --resolution lowest).
 _VALUE_FLAGS = {
     "--python", "--with", "--index", "--index-url", "--extra-index-url",
-    "-c", "--constraint",
+    "-c", "--constraint", "-r", "--requirement", "--target", "--prefix",
+    "--root", "--resolution", "--python-preference", "-f", "--find-links",
 }
 
 _SAFE_NAME = re.compile(r"^[A-Za-z0-9@][A-Za-z0-9@/#:._+-]*$")


### PR DESCRIPTION
## What

Package-name parsing mistook flag values, shell quoting, and manager subcommand aliases for package names — breaking the default `posting` install and the update/remove commands for several tools.


https://github.com/user-attachments/assets/499f8cfe-c563-4de2-9f54-4f5fa116c98b

## How it's fixed

- **Parse after the install verb.** Anchor on the shipped `_CLASSIFY` grammar and read the args after it — skips wrappers (`sudo arch -arm64 …`), chained commands (`brew tap … && brew install …`), and the eopkg `it` alias, with no new shell parser.
- **Skip value-taking flags** (`--python`, `--index-url`, …), scoped to uv/pip/pipx so `nix-env -i bat` is untouched.
- **Extras kept for install, stripped for lifecycle** (`yt-dlp[default]` installs; `yt-dlp` updates/removes).
- **Allowlist gate** on every derived name/target/bin — a scraped or malformed command can't emit a destructive `remove`/`rm` (blocks path traversal in the go template).
- **`_prefer_uv` preserves a winning `uv` method verbatim** (keeps the pin); pip winners translate to a shell-quoted `uv tool install`, refusing an invalid target.
- **Lifecycle commands rederive from the stored command**, so already-corrupted ledgers self-heal.

## Tests

Regressions for every case above. Full suite: `python -m unittest discover -s tests` → **146 passed**.