### PR TITLE
Fix crash on narrow terminals (<80 cols) in the results pane

### DIFF
--- a/tests/test_narrow_terminal.py
+++ b/tests/test_narrow_terminal.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import patch
+
+import tuistore.app as app_module
+from tuistore.app import StoreApp
+
+
+class NarrowTerminalTest(unittest.IsolatedAsyncioTestCase):
+    """Below ~80 columns, #results (width: 1fr) used to get squeezed to a
+    zero-or-negative content width, which crashed deep in Textual/Rich's
+    text-wrapping code (ValueError: range() arg 3 must not be zero) as soon
+    as the option list tried to measure its own auto height. #results now
+    has a min-width floor so it can never be handed a non-positive width."""
+
+    async def test_narrow_width_does_not_crash(self) -> None:
+        with patch.object(app_module.DIRS, "load_state", return_value={"welcomed": True}), \
+             patch.object(app_module.DIRS, "save_state"), \
+             patch.object(StoreApp, "scan_managers"):
+            app = StoreApp()
+            async with app.run_test(size=(60, 24)) as pilot:
+                app.query_one("#results").focus()
+                await pilot.pause()
+
+                results = app.query_one("#results")
+                self.assertGreater(results.option_count, 0)
+                self.assertGreater(results.size.width, 0)
+
+    async def test_very_narrow_widths_do_not_crash(self) -> None:
+        for width in (50, 60, 70):
+            with patch.object(app_module.DIRS, "load_state", return_value={"welcomed": True}), \
+                 patch.object(app_module.DIRS, "save_state"), \
+                 patch.object(StoreApp, "scan_managers"):
+                app = StoreApp()
+                async with app.run_test(size=(width, 24)) as pilot:
+                    app.query_one("#results").focus()
+                    await pilot.pause()
+
+                    results = app.query_one("#results")
+                    self.assertGreater(results.option_count, 0, f"width={width}")
+                    self.assertGreater(results.size.width, 0, f"width={width}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tuistore/app.py
+++ b/tuistore/app.py
@@ -877,7 +877,7 @@ class StoreApp(KitApp):
     #sidebar:focus {{ border: round $kit-border-focus; border-title-color: $kit-border-focus; }}
 
     #results {{
-        width: 1fr;
+        width: 1fr; min-width: 16;
         border: round $kit-border;
         border-title-color: {palette.text}; border-subtitle-color: {palette.dim};
     }}


### PR DESCRIPTION
## Summary

Below roughly 80 columns, the app raised an unhandled `ValueError: range() arg 3 must not be zero` on startup and on resize, instead of just rendering awkwardly. Reproduced headlessly via Textual's test harness:

```python
async with app.run_test(size=(70, 24)) as pilot:
    app.query_one("#results").focus()
    await pilot.pause()
```

## Root cause

`#results` (the `NavList`/`OptionList` showing the catalog) is styled `width: 1fr` with no `min-width`, sitting between `#sidebar` (fixed `width: 25`) and `#detail` (`min-width: 40`) inside a `Horizontal`. Once the sidebar and detail pane claim their space, Textual's horizontal-layout remaining-space calculation for the `1fr` column can hit zero on narrow terminals.

`OptionList` defaults to `height: auto`, so Textual has to call `OptionList.get_content_height()` to measure it. That method subtracts its own option padding from the given width with no floor, and passes the (now negative) result into Rich's text-wrapping code. `rich.cells.chop_cells()` then tries to build a `range(0, len(text), width)` with a zero/negative step, which raises.

The crash originates in Textual/Rich's layout and wrapping internals, not in tuistore's own row-truncation logic — `_result_row()` already floors its truncation width via `max(24, width - 2)`. Since patching a third-party dependency isn't appropriate here, the fix lives on the tuistore side.

## Fix

Give `#results` a `min-width: 16` in `tuistore/app.py`, so Textual's box-model resolution can never hand it a non-positive width — mirroring the `min_width` ricekit's `Splitter` already uses as the sane floor for the same pane. Widths of 80+ are unaffected, since their natural `1fr` allocation already exceeds this floor (verified no change in `#results`/`#sidebar`/`#detail` sizes at 100/120/150/200 columns before vs. after the fix).

## Test plan

- [x] Added `tests/test_narrow_terminal.py`, which renders the app at 50/60/70 columns and asserts it doesn't raise and the results list still has content, following the async Textual test pattern used elsewhere in `tests/`.
- [x] Reproduced the crash before the fix at width=70 (and 50/60), confirmed it's gone after the fix at 50/60/70/80/120/200.
- [x] Confirmed real catalog rows still render with expected columns (language dot, name, star/installed badges, star count, description) at 80/120/200 columns, unchanged from before the fix.
- [x] Full suite: `uv run python -m unittest discover tests -v` — 149 passed, 0 failures/errors.
- [x] Sanity-checked on Python 3.11 and 3.12 in addition to 3.13 — all green.