### PR TITLE
Wrap footer in ricekit's KitFooter as a safety net on top of #27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 dependencies = [
     "textual>=1.0",
     "httpx>=0.27",
-    "ricekit>=0.2.0",
+    "ricekit>=0.3.0",
 ]
 keywords = ["tui", "terminal", "textual", "app-store", "package-manager", "awesome-tuis"]
 classifiers = [

--- a/tests/test_footer.py
+++ b/tests/test_footer.py
@@ -1,20 +1,43 @@
 import unittest
 from unittest.mock import patch
 
-from textual.widgets import Footer
+from ricekit.widgets import KitFooter
 
 import tuistore.app as app_module
 from tuistore.app import StoreApp
 
 
+async def _settle(pilot) -> None:
+    """KitFooter's overflow check chains onto its own call_after_refresh
+    hop on top of the app's own mount/bindings-changed refresh — one pause
+    isn't reliably enough to drain the whole chain on a loaded CI runner
+    (see ricekit's own test_footer.py, which hit the same thing)."""
+    for _ in range(5):
+        await pilot.pause()
+
+
 class FooterTest(unittest.IsolatedAsyncioTestCase):
-    async def test_footer_fits_small_screen(self) -> None:
+    async def _run(self, width: int, height: int = 24):
         with patch.object(app_module.DIRS, "load_state", return_value={"welcomed": True}), \
              patch.object(app_module.DIRS, "save_state"), \
              patch.object(StoreApp, "scan_managers"):
             app = StoreApp()
-            async with app.run_test(size=(80, 24)) as pilot:
+            async with app.run_test(size=(width, height)) as pilot:
                 app.query_one("#results").focus()
-                await pilot.pause()
+                await _settle(pilot)
+                return app.query_one(KitFooter)
 
-                self.assertEqual(app.query_one(Footer).max_scroll_x, 0)
+    async def test_footer_fits_small_screen(self) -> None:
+        footer = await self._run(80)
+        self.assertEqual(footer.max_scroll_x, 0)
+
+    async def test_footer_fits_narrower_than_ever_tested_before(self) -> None:
+        # PR #27 hand-picked the 7 keys shown here and verified them at
+        # 80x24 only. KitFooter is a safety net on top of that curation —
+        # this proves the same 7 (plus the always-present ? and q) stay
+        # overflow-free well below that, not just at the one width that
+        # happened to get tested.
+        for width in (40, 50, 60):
+            with self.subTest(width=width):
+                footer = await self._run(width)
+                self.assertEqual(footer.max_scroll_x, 0)

--- a/tuistore/app.py
+++ b/tuistore/app.py
@@ -17,12 +17,12 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Footer, Input, Markdown, Static
+from textual.widgets import Input, Markdown, Static
 from textual.widgets.option_list import Option
 
 from ricekit import KitApp, icons, palette
 from ricekit.modals import HelpModal, PickerModal, ThemeModal  # noqa: F401
-from ricekit.widgets import KitScroll, NavList, Splitter, pop_in
+from ricekit.widgets import KitFooter, KitScroll, NavList, Splitter, pop_in
 
 from . import __version__, github, installed as inst, platform
 from .catalog import Catalog, Entry, load, refetch, search
@@ -984,7 +984,7 @@ class StoreApp(KitApp):
             with Vertical(id="detail"):
                 with KitScroll(id="detailscroll"):
                     yield Static(id="d-body")
-        yield Footer(compact=True, show_command_palette=False)
+        yield KitFooter(show_command_palette=False)
 
     def on_mount(self) -> None:
         state = DIRS.load_state()


### PR DESCRIPTION
## What

Swaps the stock `Footer(compact=True, show_command_palette=False)` for `KitFooter(show_command_palette=False)`, new in ricekit v0.3.0.

This builds directly on #27, not around it. Every `show=True`/`show=False` choice from that PR — including deliberately keeping `?` and `q` visible — is unchanged here. `KitFooter` doesn't get to invent visibility beyond what's already marked `show=True`; it only ever guarantees that set can't overflow.

## Why

#27 fixed the real overflow bug (46 columns cut off at 80-column terminals) by hand-picking 7 bindings to keep visible, verified at 80×24. That diagnosis is what led to building `KitFooter` upstream in ricekit: a `Footer` that measures actual rendered layout on mount and on every resize, and trims deterministically if it ever doesn't fit — rather than any one app (or any one terminal width) needing to be gotten right by hand.

## Verified

- The exact same 7 keys (`/ i r s o ? q`) render identically at 60/80/120/200 columns — no change in normal/wide behavior.
- Below what #27 tested, it degrades gracefully instead of risking overflow again: 4 keys at 40 columns, 6 at 50, all 7 from 60 up — `max_scroll_x == 0` at every width checked.
- Full suite: 151 tests pass on Python 3.11/3.12/3.13.
- New test (`test_footer_fits_narrower_than_ever_tested_before`) locks in the 40/50/60-column behavior, which nothing in the suite covered before.

## Test plan

- [x] `uv run python -m unittest discover tests -v` — 151 passed, 0 failures, on 3.11/3.12/3.13
- [x] Manually probed visible footer keys at 40/50/60/80/120/200 columns
