### PR TITLE
catalog: add stocksTUI, soundcloud-tui, onepace

### DIFF
--- a/tools/build_catalog.py
+++ b/tools/build_catalog.py
@@ -351,6 +351,9 @@ ESSENTIAL_BREW = {  # keyed by owner/repo slug
 ESSENTIAL_NO_BREW = {
     # author confirmed no formula exists (github.com/Gheat1/tuistore/issues/32)
     "vashhdev/onepace",
+    # verified via formulae.brew.sh's formula + cask API (both 404) — a
+    # brand new, single-star personal project with no packaging at all
+    "laguser/soundcloud-tui",
 }
 
 

--- a/tools/build_catalog.py
+++ b/tools/build_catalog.py
@@ -227,6 +227,7 @@ ESSENTIALS: list[tuple[str, str, str]] = [
     ("gping", "https://github.com/orf/gping", "Dashboards"),
     ("wlocks", "https://github.com/programmersd21/wlocks", "Dashboards"),
     ("flow", "https://github.com/programmersd21/flow", "Dashboards"),
+    ("stocksTUI", "https://github.com/andriy-git/stocksTUI", "Dashboards"),
     # File Managers
     ("yazi", "https://github.com/sxyazi/yazi", "File Managers"),
     ("nnn", "https://github.com/jarun/nnn", "File Managers"),
@@ -248,6 +249,8 @@ ESSENTIALS: list[tuple[str, str, str]] = [
     ("chafa", "https://github.com/hpjansson/chafa", "Multimedia"),
     ("viu", "https://github.com/atanunq/viu", "Multimedia"),
     ("timg", "https://github.com/hzeller/timg", "Multimedia"),
+    ("soundcloud-tui", "https://github.com/laguser/soundcloud-tui", "Multimedia"),
+    ("onepace", "https://github.com/vashhdev/onepace", "Multimedia"),
     # Productivity
     ("Taskwarrior", "https://github.com/GothenburgBitFactory/taskwarrior", "Productivity"),
     ("calcure", "https://github.com/anufrievroman/calcure", "Productivity"),
@@ -340,6 +343,14 @@ ESSENTIAL_BREW = {  # keyed by owner/repo slug
     "GothenburgBitFactory/taskwarrior": "task",
     "pipeseroni/pipes.sh": "pipes-sh",
     "aome510/spotify-player": "spotify_player",
+}
+
+# Essentials confirmed to have no Homebrew formula at all — skip the guessed
+# `brew install <repo-name>` fallback rather than invent one that doesn't
+# exist and would just 404.
+ESSENTIAL_NO_BREW = {
+    # author confirmed no formula exists (github.com/Gheat1/tuistore/issues/32)
+    "vashhdev/onepace",
 }
 
 
@@ -519,9 +530,11 @@ async def add_methods(entries: list[dict], scrape_top: int) -> None:
         # the naive guess below and must not be allowed to coexist with it.
         if e.get("_essential") and not has_method_kind(methods, "brew"):
             owner, repo = parse_repo(e["url"])
-            formula = ESSENTIAL_BREW.get(f"{owner}/{repo}", repo.lower())
-            methods.append(make("brew", f"brew install {formula}",
-                                source="inferred", note="homebrew").to_dict())
+            slug = f"{owner}/{repo}"
+            if slug not in ESSENTIAL_NO_BREW:
+                formula = ESSENTIAL_BREW.get(slug, repo.lower())
+                methods.append(make("brew", f"brew install {formula}",
+                                    source="inferred", note="homebrew").to_dict())
         deduped = dedupe_methods(methods)
         if deduped:
             e["methods"] = deduped

--- a/tuistore/data/catalog.json
+++ b/tuistore/data/catalog.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-26T05:49:13Z",
+ "generated_at": "2026-07-26T05:54:54Z",
  "source": "awesome-tuis (rothgar/awesome-tuis) + modern terminal essentials + Gheat suite",
  "count": 822,
  "entries": [
@@ -500,7 +500,7 @@
    "url": "https://github.com/openai/codex",
    "description": "Lightweight coding agent that runs in your terminal",
    "category": "Development",
-   "stars": 101475,
+   "stars": 101477,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-26T05:06:54Z",
@@ -1472,7 +1472,7 @@
    "url": "https://github.com/rclone/rclone",
    "description": "\"rsync for cloud storage\" - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Azure Blob, Azure Files, Yandex Files",
    "category": "CLI Tools",
-   "stars": 58707,
+   "stars": 58708,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-25T17:48:50Z",
@@ -4682,7 +4682,7 @@
    "url": "https://github.com/ogulcancelik/herdr",
    "description": "Agent multiplexer that lives in your terminal.",
    "category": "Development",
-   "stars": 20849,
+   "stars": 20850,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-26T01:26:44Z",
@@ -4925,7 +4925,7 @@
    "url": "https://github.com/MHNightCat/superfile",
    "description": "Pretty fancy and modern terminal file manager.",
    "category": "File Managers",
-   "stars": 19905,
+   "stars": 19906,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-26T00:37:14Z",
@@ -4980,7 +4980,7 @@
    "url": "https://github.com/yorukot/superfile",
    "description": "Pretty fancy and modern terminal file manager",
    "category": "File Managers",
-   "stars": 19905,
+   "stars": 19906,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-26T00:37:14Z",
@@ -5044,7 +5044,7 @@
    "url": "https://github.com/fathyb/carbonyl",
    "description": "Chromium running inside your terminal",
    "category": "Web",
-   "stars": 19287,
+   "stars": 19288,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2024-07-01T14:31:50Z",
@@ -7744,7 +7744,7 @@
    "url": "https://github.com/microsoft/inshellisense",
    "description": "IDE style command line auto complete",
    "category": "Productivity",
-   "stars": 10547,
+   "stars": 10548,
    "language": "TypeScript",
    "archived": false,
    "pushed_at": "2026-07-25T16:47:07Z",
@@ -13426,7 +13426,7 @@
    "stars": 2924,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-23T07:49:28Z",
+   "pushed_at": "2026-07-26T05:53:43Z",
    "homepage": "https://kewplayer.com",
    "methods": [
     {
@@ -19163,7 +19163,7 @@
    "url": "https://github.com/christo-auer/eilmeldung",
    "description": "RSS reader, supporting many RSS providers, bulk-operations and configuration options.",
    "category": "Web",
-   "stars": 916,
+   "stars": 917,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-24T19:00:20Z",
@@ -19870,7 +19870,7 @@
    "stars": 777,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-26T04:59:22Z",
+   "pushed_at": "2026-07-26T05:48:41Z",
    "homepage": "https://vinhnx.github.io",
    "methods": [
     {
@@ -25926,32 +25926,11 @@
    ]
   },
   {
-   "name": "terminalperiodictable",
-   "url": "https://github.com/velorek1/terminalperiodictable",
-   "description": "A beautiful TUI periodic table for Unix systems coded in C.",
-   "category": "Miscellaneous",
-   "stars": 144,
-   "language": "C",
-   "archived": false,
-   "pushed_at": "2025-08-01T19:13:39Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/velorek1/terminalperiodictable && cd terminalperiodictable",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "wlctl",
    "url": "https://github.com/aashish-thapa/wlctl",
    "description": "🛜 TUI for managing wifi/ethernet/vpn on Linux with Network Manager",
    "category": "CLI Tools",
-   "stars": 144,
+   "stars": 145,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-24T18:00:35Z",
@@ -26006,6 +25985,27 @@
       "brew"
      ],
      "note": "homebrew"
+    }
+   ]
+  },
+  {
+   "name": "terminalperiodictable",
+   "url": "https://github.com/velorek1/terminalperiodictable",
+   "description": "A beautiful TUI periodic table for Unix systems coded in C.",
+   "category": "Miscellaneous",
+   "stars": 144,
+   "language": "C",
+   "archived": false,
+   "pushed_at": "2025-08-01T19:13:39Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/velorek1/terminalperiodictable && cd terminalperiodictable",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
     }
    ]
   },
@@ -32569,15 +32569,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install soundcloud-tui",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },

--- a/tuistore/data/catalog.json
+++ b/tuistore/data/catalog.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-20T16:34:03Z",
+ "generated_at": "2026-07-26T05:49:13Z",
  "source": "awesome-tuis (rothgar/awesome-tuis) + modern terminal essentials + Gheat suite",
- "count": 819,
+ "count": 822,
  "entries": [
   {
    "name": "ltui",
@@ -11,9 +11,9 @@
    "description": "A fast, clean TUI for Linear — status-grouped issues, instant startup, full keyboard + mouse control.",
    "author_note": "by Gheat · the app the whole suite (and ricekit) grew out of",
    "featured": true,
-   "stars": 80,
+   "stars": 88,
    "archived": false,
-   "pushed_at": "2026-07-15T00:59:32Z",
+   "pushed_at": "2026-07-23T20:52:00Z",
    "methods": [
     {
      "kind": "uv",
@@ -41,9 +41,9 @@
    "description": "An animated TUI player for Navidrome — cover art in the terminal, playback via mpv, themes via ricekit.",
    "author_note": "by Gheat · music + cover art, right in your terminal",
    "featured": true,
-   "stars": 20,
+   "stars": 28,
    "archived": false,
-   "pushed_at": "2026-07-19T21:19:17Z",
+   "pushed_at": "2026-07-21T20:35:49Z",
    "methods": [
     {
      "kind": "uv",
@@ -63,9 +63,9 @@
    "description": "🍚 A developer's TUI suite for Textual — themes, widgets, modals, icons, and the design system behind ltui. This store is built on it.",
    "author_note": "by Gheat · the design system tuistore itself is built on — run ricekit-gallery",
    "featured": true,
-   "stars": 13,
+   "stars": 22,
    "archived": false,
-   "pushed_at": "2026-07-19T20:21:49Z",
+   "pushed_at": "2026-07-22T23:47:15Z",
    "methods": [
     {
      "kind": "uv",
@@ -87,7 +87,7 @@
    "featured": true,
    "stars": 2,
    "archived": false,
-   "pushed_at": "2026-07-18T17:35:44Z",
+   "pushed_at": "2026-07-23T16:44:47Z",
    "homepage": "https://crates.io/crates/haal",
    "methods": [
     {
@@ -116,9 +116,9 @@
    "description": "A Minecraft TUI/CLI launcher written in Rust — launch the game from your terminal.",
    "author_note": "by @objz · a Minecraft launcher that lives in the terminal",
    "featured": true,
-   "stars": 59,
+   "stars": 60,
    "archived": false,
-   "pushed_at": "2026-07-12T16:53:12Z",
+   "pushed_at": "2026-07-25T17:05:17Z",
    "methods": [
     {
      "kind": "brew",
@@ -160,9 +160,9 @@
    "description": "A pomodoro timer written in pure C — simple, focused, terminal-native.",
    "author_note": "by @gabrielzschmitz · a tiny pomodoro timer in pure C",
    "featured": true,
-   "stars": 438,
+   "stars": 442,
    "archived": false,
-   "pushed_at": "2026-07-20T03:07:43Z",
+   "pushed_at": "2026-07-22T20:59:13Z",
    "methods": [
     {
      "kind": "source",
@@ -182,9 +182,9 @@
    "description": "A cross-platform network-troubleshooting TUI — pinpoints DNS, TCP, TLS, HTTP and proxy failures, and suggests fixes.",
    "author_note": "by @heymaikol · diagnoses network failures and tells you how to fix them",
    "featured": true,
-   "stars": 11,
+   "stars": 63,
    "archived": false,
-   "pushed_at": "2026-07-19T23:08:15Z",
+   "pushed_at": "2026-07-25T20:08:52Z",
    "methods": [
     {
      "kind": "brew",
@@ -226,7 +226,7 @@
    "description": "A polished terminal wizard for creating a reproducible Paper Minecraft server — turns plain-language choices into ready-to-run Docker Compose or native Java server files.",
    "author_note": "by @NolanCotter · stand up a Minecraft server without the usual yak-shaving",
    "featured": true,
-   "stars": 2,
+   "stars": 3,
    "archived": false,
    "pushed_at": "2026-07-19T06:59:46Z",
    "methods": [
@@ -248,7 +248,7 @@
    "description": "A blazing-fast pywal-like color palette generator, written in C.",
    "author_note": "by @nitinbhat972 · pywal's speed problem, solved in C",
    "featured": true,
-   "stars": 118,
+   "stars": 119,
    "archived": false,
    "pushed_at": "2026-06-16T13:35:56Z",
    "methods": [
@@ -312,10 +312,10 @@
    "url": "https://github.com/sst/opencode",
    "description": "AI coding agent, built for the terminal",
    "category": "Development",
-   "stars": 187820,
+   "stars": 189723,
    "language": "TypeScript",
    "archived": false,
-   "pushed_at": "2026-07-20T16:29:57Z",
+   "pushed_at": "2026-07-26T04:31:47Z",
    "homepage": "https://opencode.ai",
    "methods": [
     {
@@ -433,10 +433,10 @@
    "url": "https://github.com/yt-dlp/yt-dlp",
    "description": "A feature-rich command-line audio/video downloader",
    "category": "Multimedia",
-   "stars": 179081,
+   "stars": 180108,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-14T14:14:21Z",
+   "pushed_at": "2026-07-23T16:54:49Z",
    "homepage": "https://discord.gg/H5MNcFW63r",
    "methods": [
     {
@@ -496,45 +496,14 @@
    ]
   },
   {
-   "name": "Neovim",
-   "url": "https://github.com/neovim/neovim",
-   "description": "Vim-fork focused on extensibility and usability",
-   "category": "Editors",
-   "stars": 101260,
-   "language": "Vim Script",
-   "archived": false,
-   "pushed_at": "2026-07-20T16:30:30Z",
-   "homepage": "https://neovim.io",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/neovim/neovim && cd neovim",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install neovim",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
    "name": "codex",
    "url": "https://github.com/openai/codex",
    "description": "Lightweight coding agent that runs in your terminal",
    "category": "Development",
-   "stars": 99998,
+   "stars": 101475,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T16:30:01Z",
+   "pushed_at": "2026-07-26T05:06:54Z",
    "methods": [
     {
      "kind": "script",
@@ -593,11 +562,42 @@
    ]
   },
   {
+   "name": "Neovim",
+   "url": "https://github.com/neovim/neovim",
+   "description": "Vim-fork focused on extensibility and usability",
+   "category": "Editors",
+   "stars": 101347,
+   "language": "Vim Script",
+   "archived": false,
+   "pushed_at": "2026-07-26T04:18:47Z",
+   "homepage": "https://neovim.io",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/neovim/neovim && cd neovim",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install neovim",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
    "name": "thefuck",
    "url": "https://github.com/nvbn/thefuck",
    "description": "Magnificent app which corrects your previous console command.",
    "category": "Shell & Prompt",
-   "stars": 97551,
+   "stars": 97568,
    "language": "Python",
    "archived": false,
    "pushed_at": "2024-07-19T14:56:13Z",
@@ -687,10 +687,10 @@
    "url": "https://github.com/junegunn/fzf",
    "description": "A general-purpose command-line fuzzy finder",
    "category": "Miscellaneous",
-   "stars": 81866,
+   "stars": 81971,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T13:42:51Z",
+   "pushed_at": "2026-07-24T12:38:43Z",
    "homepage": "https://junegunn.github.io/fzf/",
    "methods": [
     {
@@ -833,10 +833,10 @@
    "url": "https://github.com/jesseduffield/lazygit",
    "description": "Simple terminal UI for git commands",
    "category": "Development",
-   "stars": 80548,
+   "stars": 80735,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T15:08:34Z",
+   "pushed_at": "2026-07-25T16:39:19Z",
    "methods": [
     {
      "kind": "brew",
@@ -891,6 +891,21 @@
      "note": "from README"
     },
     {
+     "kind": "eopkg",
+     "command": "sudo eopkg install lazygit",
+     "source": "readme",
+     "requires": [
+      "eopkg"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "solus"
+     ],
+     "note": "from README"
+    },
+    {
      "kind": "apt",
      "command": "sudo apt install lazygit",
      "source": "readme",
@@ -936,21 +951,6 @@
      "note": "from README"
     },
     {
-     "kind": "apt",
-     "command": "apt install lazygit",
-     "source": "readme",
-     "requires": [
-      "apt"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "debian"
-     ],
-     "note": "from README"
-    },
-    {
      "kind": "go",
      "command": "go install github.com/jesseduffield/lazygit@latest",
      "source": "inferred",
@@ -975,10 +975,10 @@
    "url": "https://github.com/BurntSushi/ripgrep",
    "description": "Ripgrep recursively searches directories for a regex pattern while respecting your gitignore",
    "category": "CLI Tools",
-   "stars": 66362,
+   "stars": 66533,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T13:16:05Z",
+   "pushed_at": "2026-07-24T12:03:10Z",
    "methods": [
     {
      "kind": "brew",
@@ -1120,10 +1120,10 @@
    "url": "https://github.com/tldr-pages/tldr",
    "description": "Collaborative cheatsheets for console commands 📚.",
    "category": "CLI Tools",
-   "stars": 63149,
+   "stars": 63204,
    "language": "Markdown",
    "archived": false,
-   "pushed_at": "2026-07-20T16:23:42Z",
+   "pushed_at": "2026-07-26T05:38:33Z",
    "homepage": "https://tldr.sh",
    "methods": [
     {
@@ -1181,7 +1181,7 @@
    "url": "https://github.com/sharkdp/bat",
    "description": "A cat(1) clone with wings.",
    "category": "CLI Tools",
-   "stars": 59816,
+   "stars": 59876,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-01T20:15:58Z",
@@ -1329,10 +1329,10 @@
    "url": "https://github.com/starship/starship",
    "description": "☄🌌️ The minimal, blazing-fast, and infinitely customizable prompt for any shell!",
    "category": "Shell & Prompt",
-   "stars": 58964,
+   "stars": 59077,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T05:00:39Z",
+   "pushed_at": "2026-07-26T05:16:59Z",
    "homepage": "https://starship.rs",
    "methods": [
     {
@@ -1472,10 +1472,10 @@
    "url": "https://github.com/rclone/rclone",
    "description": "\"rsync for cloud storage\" - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Azure Blob, Azure Files, Yandex Files",
    "category": "CLI Tools",
-   "stars": 58468,
+   "stars": 58707,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T10:46:44Z",
+   "pushed_at": "2026-07-25T17:48:50Z",
    "homepage": "https://rclone.org",
    "methods": [
     {
@@ -1513,7 +1513,7 @@
    "description": "Is a Python library for rich text and beautiful formatting in the terminal.",
    "category": "Libraries",
    "language": "Python",
-   "stars": 56893,
+   "stars": 56948,
    "archived": false,
    "pushed_at": "2026-06-23T03:10:19Z",
    "homepage": "https://rich.readthedocs.io/en/latest/",
@@ -1561,7 +1561,7 @@
    "url": "https://github.com/wagoodman/dive",
    "description": "A tool for exploring each layer in a docker image",
    "category": "Docker/LXC/K8s",
-   "stars": 54333,
+   "stars": 54357,
    "language": "Go",
    "archived": false,
    "pushed_at": "2025-12-15T17:20:36Z",
@@ -1656,11 +1656,11 @@
     {
      "kind": "go",
      "command": "go install github.com/wagoodman/dive@latest",
-     "source": "inferred",
+     "source": "readme",
      "requires": [
       "go"
      ],
-     "note": "module path from repo"
+     "note": "from README"
     },
     {
      "kind": "source",
@@ -1678,7 +1678,7 @@
    "url": "https://github.com/jesseduffield/lazydocker",
    "description": "The lazier way to manage everything docker",
    "category": "Docker/LXC/K8s",
-   "stars": 52105,
+   "stars": 52161,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-04-19T02:51:06Z",
@@ -1774,10 +1774,10 @@
    "url": "https://github.com/tmux/tmux",
    "description": "Terminal multiplexer",
    "category": "Productivity",
-   "stars": 47903,
+   "stars": 48048,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-20T15:26:12Z",
+   "pushed_at": "2026-07-25T22:07:45Z",
    "methods": [
     {
      "kind": "source",
@@ -1804,10 +1804,10 @@
    "url": "https://github.com/helix-editor/helix",
    "description": "A post-modern modal text editor.",
    "category": "Editors",
-   "stars": 45531,
+   "stars": 45593,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T16:31:22Z",
+   "pushed_at": "2026-07-23T16:03:38Z",
    "homepage": "https://helix-editor.com",
    "methods": [
     {
@@ -1853,10 +1853,10 @@
    "url": "https://github.com/cli/cli",
    "description": "GitHub’s official command line tool",
    "category": "Development",
-   "stars": 45335,
+   "stars": 45417,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-17T10:18:56Z",
+   "pushed_at": "2026-07-24T17:57:10Z",
    "homepage": "https://cli.github.com",
    "methods": [
     {
@@ -1894,7 +1894,7 @@
    "description": "A Go framework based on Elm to build functional and fun terminal apps",
    "category": "Libraries",
    "language": "Go",
-   "stars": 43848,
+   "stars": 43963,
    "archived": false,
    "pushed_at": "2026-07-20T09:03:09Z",
    "methods": [
@@ -1923,10 +1923,10 @@
    "url": "https://github.com/sharkdp/fd",
    "description": "A simple, fast and user-friendly alternative to 'find'",
    "category": "CLI Tools",
-   "stars": 43799,
+   "stars": 43874,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-15T20:22:26Z",
+   "pushed_at": "2026-07-24T20:22:08Z",
    "methods": [
     {
      "kind": "apt",
@@ -2088,45 +2088,14 @@
    ]
   },
   {
-   "name": "Vim",
-   "url": "https://github.com/vim/vim",
-   "description": "The official Vim repository",
-   "category": "Editors",
-   "stars": 40650,
-   "language": "Vim Script",
-   "archived": false,
-   "pushed_at": "2026-07-20T16:07:31Z",
-   "homepage": "https://www.vim.org",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/vim/vim && cd vim",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install vim",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
    "name": "yazi",
    "url": "https://github.com/sxyazi/yazi",
    "description": "Blazing fast terminal file manager written in Rust, based on async I/O.",
    "category": "File Managers",
-   "stars": 40528,
+   "stars": 40763,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T06:44:06Z",
+   "pushed_at": "2026-07-26T02:58:12Z",
    "homepage": "https://yazi-rs.github.io",
    "methods": [
     {
@@ -2168,14 +2137,45 @@
    ]
   },
   {
+   "name": "Vim",
+   "url": "https://github.com/vim/vim",
+   "description": "The official Vim repository",
+   "category": "Editors",
+   "stars": 40678,
+   "language": "Vim Script",
+   "archived": false,
+   "pushed_at": "2026-07-25T17:13:26Z",
+   "homepage": "https://www.vim.org",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/vim/vim && cd vim",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install vim",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
    "name": "Nushell",
    "url": "https://github.com/nushell/nushell",
    "description": "A new type of shell",
    "category": "Shell & Prompt",
-   "stars": 40052,
+   "stars": 40089,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T16:10:50Z",
+   "pushed_at": "2026-07-26T01:02:11Z",
    "homepage": "https://www.nushell.sh/",
    "methods": [
     {
@@ -2234,7 +2234,7 @@
    "description": "React for Node.js interactive command-line apps",
    "category": "Libraries",
    "language": "TypeScript",
-   "stars": 39390,
+   "stars": 39466,
    "archived": false,
    "pushed_at": "2026-07-16T13:07:19Z",
    "homepage": "https://term.ink",
@@ -2260,11 +2260,129 @@
    ]
   },
   {
+   "name": "croc",
+   "url": "https://github.com/schollz/croc",
+   "description": "Easily and securely send things from one computer to another :crocodile: :package:",
+   "category": "CLI Tools",
+   "stars": 38481,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-24T13:17:11Z",
+   "homepage": "https://getcroc.com",
+   "methods": [
+    {
+     "kind": "script",
+     "command": "curl https://getcroc.com | bash",
+     "source": "readme",
+     "requires": [
+      "curl"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install croc",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "scoop",
+     "command": "scoop install croc",
+     "source": "readme",
+     "requires": [
+      "scoop"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "choco",
+     "command": "choco install croc",
+     "source": "readme",
+     "requires": [
+      "choco"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "winget",
+     "command": "winget install schollz.croc",
+     "source": "readme",
+     "requires": [
+      "winget"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "nix",
+     "command": "nix-env -i croc",
+     "source": "readme",
+     "requires": [
+      "nix"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "script",
+     "command": "wget -qO- https://getcroc.com | bash",
+     "source": "readme",
+     "requires": [
+      "curl"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "pacman",
+     "command": "pacman -S croc",
+     "source": "readme",
+     "requires": [
+      "pacman"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "arch"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/schollz/croc@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/schollz/croc && cd croc",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "HTTPie",
    "url": "https://github.com/httpie/cli",
    "description": "🥧 HTTPie CLI — modern, user-friendly command-line HTTP client for the API era. JSON support, colors, sessions, downloads, plugins & more.",
    "category": "CLI Tools",
-   "stars": 38329,
+   "stars": 38342,
    "language": "Python",
    "archived": false,
    "pushed_at": "2024-12-17T17:30:35Z",
@@ -2313,7 +2431,7 @@
    "url": "https://github.com/ajeetdsouza/zoxide",
    "description": "A smarter cd command. Supports all major shells.",
    "category": "Shell & Prompt",
-   "stars": 38132,
+   "stars": 38247,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-20T12:05:30Z",
@@ -2447,7 +2565,7 @@
    "description": "Is a TUI (Text User Interface) framework for Python inspired by modern web development.",
    "category": "Libraries",
    "language": "Python",
-   "stars": 36672,
+   "stars": 36744,
    "archived": false,
    "pushed_at": "2026-07-11T06:02:34Z",
    "homepage": "https://textual.textualize.io/",
@@ -2491,132 +2609,14 @@
    ]
   },
   {
-   "name": "croc",
-   "url": "https://github.com/schollz/croc",
-   "description": "Easily and securely send things from one computer to another :crocodile: :package:",
-   "category": "CLI Tools",
-   "stars": 36172,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-20T16:22:45Z",
-   "homepage": "https://schollz.com/software/croc6",
-   "methods": [
-    {
-     "kind": "script",
-     "command": "curl https://getcroc.schollz.com | bash",
-     "source": "readme",
-     "requires": [
-      "curl"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install croc",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "scoop",
-     "command": "scoop install croc",
-     "source": "readme",
-     "requires": [
-      "scoop"
-     ],
-     "os": [
-      "windows"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "choco",
-     "command": "choco install croc",
-     "source": "readme",
-     "requires": [
-      "choco"
-     ],
-     "os": [
-      "windows"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "winget",
-     "command": "winget install schollz.croc",
-     "source": "readme",
-     "requires": [
-      "winget"
-     ],
-     "os": [
-      "windows"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "nix",
-     "command": "nix-env -i croc",
-     "source": "readme",
-     "requires": [
-      "nix"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "script",
-     "command": "wget -qO- https://getcroc.schollz.com | bash",
-     "source": "readme",
-     "requires": [
-      "curl"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "pacman",
-     "command": "pacman -S croc",
-     "source": "readme",
-     "requires": [
-      "pacman"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "arch"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/schollz/croc@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/schollz/croc && cd croc",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "mpv",
    "url": "https://github.com/mpv-player/mpv",
    "description": "🎥 Command line media player",
    "category": "Multimedia",
-   "stars": 36087,
+   "stars": 36186,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-14T19:13:03Z",
+   "pushed_at": "2026-07-24T12:53:06Z",
    "homepage": "https://mpv.io",
    "methods": [
     {
@@ -2644,10 +2644,10 @@
    "url": "https://github.com/jqlang/jq",
    "description": "Command-line JSON processor",
    "category": "CLI Tools",
-   "stars": 35253,
+   "stars": 35278,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-19T12:27:46Z",
+   "pushed_at": "2026-07-26T01:10:36Z",
    "homepage": "https://jqlang.org",
    "methods": [
     {
@@ -2675,10 +2675,10 @@
    "url": "https://github.com/casey/just",
    "description": "🤖 Just a command runner",
    "category": "Development",
-   "stars": 34846,
+   "stars": 34950,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-19T01:57:26Z",
+   "pushed_at": "2026-07-26T04:23:14Z",
    "homepage": "https://just.systems",
    "methods": [
     {
@@ -2754,10 +2754,10 @@
    "url": "https://github.com/zellij-org/zellij",
    "description": "A terminal workspace with batteries included",
    "category": "Productivity",
-   "stars": 34393,
+   "stars": 34500,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-18T09:15:17Z",
+   "pushed_at": "2026-07-21T10:18:04Z",
    "homepage": "https://zellij.dev",
    "methods": [
     {
@@ -2812,10 +2812,10 @@
    "url": "https://github.com/derailed/k9s",
    "description": "TUI for managing a Kubernetes cluster",
    "category": "Docker/LXC/K8s",
-   "stars": 34168,
+   "stars": 34211,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-19T15:46:17Z",
+   "pushed_at": "2026-07-25T14:48:06Z",
    "homepage": "https://k9scli.io",
    "methods": [
     {
@@ -2949,10 +2949,10 @@
    "url": "https://github.com/fish-shell/fish-shell",
    "description": "The user-friendly command line shell.",
    "category": "Shell & Prompt",
-   "stars": 33891,
+   "stars": 33919,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-15T07:49:11Z",
+   "pushed_at": "2026-07-22T18:02:46Z",
    "homepage": "https://fishshell.com",
    "methods": [
     {
@@ -2998,10 +2998,10 @@
    "url": "https://github.com/aristocratos/btop",
    "description": "Resource monitor with extras",
    "category": "Dashboards",
-   "stars": 33564,
+   "stars": 33638,
    "language": "C++",
    "archived": false,
-   "pushed_at": "2026-07-18T18:04:09Z",
+   "pushed_at": "2026-07-23T21:58:39Z",
    "methods": [
     {
      "kind": "zypper",
@@ -3059,10 +3059,10 @@
    "url": "https://github.com/nicolargo/glances",
    "description": "Glances an Eye on your system. A top/htop alternative.",
    "category": "Dashboards",
-   "stars": 33137,
+   "stars": 33170,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-20T07:09:08Z",
+   "pushed_at": "2026-07-25T09:17:24Z",
    "homepage": "http://nicolargo.github.io/glances/",
    "methods": [
     {
@@ -3108,10 +3108,10 @@
    "url": "https://github.com/dandavison/delta",
    "description": "A syntax-highlighting pager for git, diff, and grep output",
    "category": "Development",
-   "stars": 31502,
+   "stars": 31558,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-05T21:23:27Z",
+   "pushed_at": "2026-07-25T00:40:33Z",
    "homepage": "https://dandavison.github.io/delta/",
    "methods": [
     {
@@ -3157,10 +3157,10 @@
    "url": "https://github.com/jdx/mise",
    "description": "Dev tools, env vars, task runner",
    "category": "Development",
-   "stars": 30929,
+   "stars": 31133,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T08:18:56Z",
+   "pushed_at": "2026-07-26T01:42:47Z",
    "homepage": "https://mise.en.dev",
    "methods": [
     {
@@ -3215,10 +3215,10 @@
    "url": "https://github.com/atuinsh/atuin",
    "description": "✨ Making your shell magical",
    "category": "Shell & Prompt",
-   "stars": 30674,
+   "stars": 30776,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T06:52:26Z",
+   "pushed_at": "2026-07-25T02:03:13Z",
    "homepage": "https://atuin.sh",
    "methods": [
     {
@@ -3273,7 +3273,7 @@
    "url": "https://github.com/chubin/wttr.in",
    "description": "The right way to check the weather",
    "category": "Miscellaneous",
-   "stars": 30145,
+   "stars": 30175,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-18T09:28:27Z",
@@ -3304,10 +3304,10 @@
    "url": "https://github.com/zyedidia/micro",
    "description": "A modern and intuitive terminal-based text editor",
    "category": "Editors",
-   "stars": 29068,
+   "stars": 29103,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T00:41:55Z",
+   "pushed_at": "2026-07-26T00:43:29Z",
    "homepage": "https://micro-editor.github.io",
    "methods": [
     {
@@ -3408,17 +3408,17 @@
      "note": "from README"
     },
     {
-     "kind": "apt",
-     "command": "apt-get install micro",
+     "kind": "eopkg",
+     "command": "eopkg install micro",
      "source": "readme",
      "requires": [
-      "apt"
+      "eopkg"
      ],
      "os": [
       "linux"
      ],
      "families": [
-      "debian"
+      "solus"
      ],
      "note": "from README"
     },
@@ -3447,7 +3447,7 @@
    "url": "https://github.com/sharkdp/hyperfine",
    "description": "A command-line benchmarking tool",
    "category": "Development",
-   "stars": 28511,
+   "stars": 28535,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-04-30T08:23:25Z",
@@ -3610,10 +3610,10 @@
    "url": "https://github.com/gitleaks/gitleaks",
    "description": "Find secrets with Gitleaks 🔑",
    "category": "Development",
-   "stars": 28211,
+   "stars": 28308,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T16:05:26Z",
+   "pushed_at": "2026-07-22T16:50:36Z",
    "homepage": "https://gitleaks.io",
    "methods": [
     {
@@ -3651,7 +3651,7 @@
    "description": "Cross-platform asynchronous I/O library - written in C",
    "category": "Libraries",
    "language": "C",
-   "stars": 27013,
+   "stars": 27034,
    "archived": false,
    "pushed_at": "2026-07-20T14:42:44Z",
    "homepage": "https://libuv.org/",
@@ -3681,10 +3681,10 @@
    "url": "https://github.com/charmbracelet/crush",
    "description": "The glamourous AI coding agent",
    "category": "Development",
-   "stars": 26670,
+   "stars": 26851,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T15:44:59Z",
+   "pushed_at": "2026-07-26T00:58:00Z",
    "methods": [
     {
      "kind": "brew",
@@ -3759,17 +3759,16 @@
      "note": "from README"
     },
     {
-     "kind": "dnf",
+     "kind": "yum",
      "command": "sudo yum install crush",
      "source": "readme",
      "requires": [
-      "dnf"
+      "yum"
      ],
      "os": [
       "linux"
      ],
      "families": [
-      "fedora",
       "rhel"
      ],
      "note": "from README"
@@ -3799,7 +3798,7 @@
    "url": "https://github.com/charmbracelet/glow",
    "description": "A markdown reader, designed from the ground up to showcase the elegance and capabilities of TUI.",
    "category": "Productivity",
-   "stars": 26413,
+   "stars": 26521,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-04-26T00:10:21Z",
@@ -3840,6 +3839,21 @@
      ],
      "families": [
       "void"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "eopkg",
+     "command": "eopkg install glow",
+     "source": "readme",
+     "requires": [
+      "eopkg"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "solus"
      ],
      "note": "from README"
     },
@@ -3892,21 +3906,6 @@
      "note": "from README"
     },
     {
-     "kind": "apt",
-     "command": "sudo apt update && sudo apt install glow",
-     "source": "readme",
-     "requires": [
-      "apt"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "debian"
-     ],
-     "note": "from README"
-    },
-    {
      "kind": "go",
      "command": "go install github.com/charmbracelet/glow@latest",
      "source": "inferred",
@@ -3931,10 +3930,10 @@
    "url": "https://github.com/Wilfred/difftastic",
    "description": "A structural diff that understands syntax 🟥🟩",
    "category": "Development",
-   "stars": 25664,
+   "stars": 25687,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T09:07:09Z",
+   "pushed_at": "2026-07-25T14:03:57Z",
    "homepage": "https://difftastic.wilfred.me.uk/",
    "methods": [
     {
@@ -3981,7 +3980,7 @@
    "description": "A tool for glamorous shell scripts",
    "category": "Libraries",
    "language": "Go",
-   "stars": 24063,
+   "stars": 24095,
    "archived": false,
    "pushed_at": "2026-07-20T09:03:01Z",
    "methods": [
@@ -4065,17 +4064,16 @@
      "note": "from README"
     },
     {
-     "kind": "dnf",
+     "kind": "yum",
      "command": "sudo yum install gum",
      "source": "readme",
      "requires": [
-      "dnf"
+      "yum"
      ],
      "os": [
       "linux"
      ],
      "families": [
-      "fedora",
       "rhel"
      ],
      "note": "from README"
@@ -4120,10 +4118,10 @@
    "url": "https://github.com/fastfetch-cli/fastfetch",
    "description": "A maintained, feature-rich and performance oriented, neofetch like system information tool.",
    "category": "Dashboards",
-   "stars": 23821,
+   "stars": 23900,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-20T14:29:33Z",
+   "pushed_at": "2026-07-24T00:50:59Z",
    "methods": [
     {
      "kind": "apt",
@@ -4232,17 +4230,17 @@
      "note": "from README"
     },
     {
-     "kind": "xbps",
-     "command": "xbps-install fastfetch",
+     "kind": "eopkg",
+     "command": "eopkg install fastfetch",
      "source": "readme",
      "requires": [
-      "xbps-install"
+      "eopkg"
      ],
      "os": [
       "linux"
      ],
      "families": [
-      "void"
+      "solus"
      ],
      "note": "from README"
     },
@@ -4271,7 +4269,7 @@
    "url": "https://github.com/dylanaraps/neofetch",
    "description": "🖼️ A command-line system information tool written in bash 3.2+",
    "category": "Dashboards",
-   "stars": 23718,
+   "stars": 23712,
    "language": "Shell",
    "archived": true,
    "pushed_at": "2024-07-19T20:19:01Z",
@@ -4301,7 +4299,7 @@
    "url": "https://github.com/AlDanial/cloc",
    "description": "Cloc counts blank lines, comment lines, and physical lines of source code in many programming languages.",
    "category": "CLI Tools",
-   "stars": 23313,
+   "stars": 23336,
    "language": "Perl",
    "archived": false,
    "pushed_at": "2026-07-17T17:21:33Z",
@@ -4331,10 +4329,10 @@
    "url": "https://github.com/JanDeDobbeleer/oh-my-posh",
    "description": "The most customisable and low-latency cross platform/shell prompt renderer",
    "category": "Shell & Prompt",
-   "stars": 23101,
+   "stars": 23161,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T00:05:36Z",
+   "pushed_at": "2026-07-24T12:43:32Z",
    "homepage": "https://ohmyposh.dev",
    "methods": [
     {
@@ -4371,7 +4369,7 @@
    "url": "https://github.com/FiloSottile/age",
    "description": "A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability.",
    "category": "Miscellaneous",
-   "stars": 22930,
+   "stars": 22998,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-03-20T21:12:32Z",
@@ -4420,10 +4418,10 @@
    "url": "https://github.com/eza-community/eza",
    "description": "A modern alternative to ls",
    "category": "CLI Tools",
-   "stars": 22680,
+   "stars": 22724,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-09T10:23:41Z",
+   "pushed_at": "2026-07-24T18:08:33Z",
    "homepage": "https://eza.rocks",
    "methods": [
     {
@@ -4469,7 +4467,7 @@
    "url": "https://github.com/extrawurst/gitui",
    "description": "Blazing fast terminal-ui for git written in rust",
    "category": "Development",
-   "stars": 22269,
+   "stars": 22287,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-17T07:32:50Z",
@@ -4615,9 +4613,9 @@
    "description": "A Rust crate for building Terminal UIs (actively maintained fork of tui-rs).",
    "category": "Libraries",
    "language": "Rust",
-   "stars": 21802,
+   "stars": 21898,
    "archived": false,
-   "pushed_at": "2026-07-20T15:44:56Z",
+   "pushed_at": "2026-07-25T21:58:52Z",
    "homepage": "https://ratatui.rs",
    "methods": [
     {
@@ -4654,7 +4652,7 @@
    "url": "https://github.com/jarun/nnn",
    "description": "N³ The unorthodox terminal file manager.",
    "category": "File Managers",
-   "stars": 21717,
+   "stars": 21729,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-17T20:06:37Z",
@@ -4680,11 +4678,69 @@
    ]
   },
   {
+   "name": "herdr",
+   "url": "https://github.com/ogulcancelik/herdr",
+   "description": "Agent multiplexer that lives in your terminal.",
+   "category": "Development",
+   "stars": 20849,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-26T01:26:44Z",
+   "homepage": "https://herdr.dev",
+   "methods": [
+    {
+     "kind": "script",
+     "command": "curl -fsSL https://herdr.dev/install.sh | sh",
+     "source": "readme",
+     "requires": [
+      "curl"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install herdr",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "cargo",
+     "command": "cargo install herdr",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall herdr",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/ogulcancelik/herdr && cd herdr",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "Goaccess",
    "url": "https://github.com/allinurl/goaccess",
    "description": "GoAccess is a real-time web log analyzer and interactive viewer that runs in a terminal in nix systems or through your browser.",
    "category": "Dashboards",
-   "stars": 20719,
+   "stars": 20729,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-20T12:26:36Z",
@@ -4706,7 +4762,7 @@
    "url": "https://github.com/antonmedv/fx",
    "description": "Terminal JSON viewer & processor",
    "category": "Development",
-   "stars": 20542,
+   "stars": 20548,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-05-11T10:15:14Z",
@@ -4746,10 +4802,10 @@
    "url": "https://github.com/charmbracelet/vhs",
    "description": "Your CLI home video recorder 📼",
    "category": "CLI Tools",
-   "stars": 20408,
+   "stars": 20457,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-06-29T09:03:26Z",
+   "pushed_at": "2026-07-24T09:30:37Z",
    "methods": [
     {
      "kind": "brew",
@@ -4812,17 +4868,16 @@
      "note": "from README"
     },
     {
-     "kind": "dnf",
+     "kind": "yum",
      "command": "sudo yum install vhs ffmpeg",
      "source": "readme",
      "requires": [
-      "dnf"
+      "yum"
      ],
      "os": [
       "linux"
      ],
      "families": [
-      "fedora",
       "rhel"
      ],
      "note": "from README"
@@ -4843,6 +4898,18 @@
      "note": "from README"
     },
     {
+     "kind": "winget",
+     "command": "winget install charmbracelet.vhs",
+     "source": "readme",
+     "requires": [
+      "winget"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
      "kind": "source",
      "command": "git clone https://github.com/charmbracelet/vhs && cd vhs",
      "source": "inferred",
@@ -4854,11 +4921,130 @@
    ]
   },
   {
+   "name": "superfile",
+   "url": "https://github.com/MHNightCat/superfile",
+   "description": "Pretty fancy and modern terminal file manager.",
+   "category": "File Managers",
+   "stars": 19905,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-26T00:37:14Z",
+   "homepage": "https://superfile.dev",
+   "methods": [
+    {
+     "kind": "winget",
+     "command": "winget install --id yorukot.superfile",
+     "source": "readme",
+     "requires": [
+      "winget"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "scoop",
+     "command": "scoop install superfile",
+     "source": "readme",
+     "requires": [
+      "scoop"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/MHNightCat/superfile@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/MHNightCat/superfile && cd superfile",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "superfile",
+   "url": "https://github.com/yorukot/superfile",
+   "description": "Pretty fancy and modern terminal file manager",
+   "category": "File Managers",
+   "stars": 19905,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-26T00:37:14Z",
+   "homepage": "https://superfile.dev",
+   "methods": [
+    {
+     "kind": "winget",
+     "command": "winget install --id yorukot.superfile",
+     "source": "readme",
+     "requires": [
+      "winget"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "scoop",
+     "command": "scoop install superfile",
+     "source": "readme",
+     "requires": [
+      "scoop"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/yorukot/superfile@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/yorukot/superfile && cd superfile",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install superfile",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
    "name": "carbonyl",
    "url": "https://github.com/fathyb/carbonyl",
    "description": "Chromium running inside your terminal",
    "category": "Web",
-   "stars": 19280,
+   "stars": 19287,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2024-07-01T14:31:50Z",
@@ -4906,7 +5092,7 @@
    "url": "https://github.com/Rigellute/spotify-tui",
    "description": "Spotify for the terminal written in Rust 🚀",
    "category": "Multimedia",
-   "stars": 19262,
+   "stars": 19273,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2024-04-04T15:03:12Z",
@@ -5012,10 +5198,10 @@
    "url": "https://github.com/videolan/vlc",
    "description": "VLC includes an ncurses interface, vlc --intf ncurses",
    "category": "Multimedia",
-   "stars": 19061,
+   "stars": 19118,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-20T14:32:44Z",
+   "pushed_at": "2026-07-25T23:29:25Z",
    "homepage": "http://www.videolan.org/vlc",
    "methods": [
     {
@@ -5034,7 +5220,7 @@
    "url": "https://github.com/browsh-org/browsh",
    "description": "A fully-modern text-based browser, rendering to TTY and browsers",
    "category": "Web",
-   "stars": 18944,
+   "stars": 18954,
    "language": "JavaScript",
    "archived": false,
    "pushed_at": "2025-07-11T16:33:02Z",
@@ -5061,188 +5247,11 @@
    ]
   },
   {
-   "name": "superfile",
-   "url": "https://github.com/MHNightCat/superfile",
-   "description": "Pretty fancy and modern terminal file manager.",
-   "category": "File Managers",
-   "stars": 18687,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-20T05:07:46Z",
-   "homepage": "https://superfile.dev",
-   "methods": [
-    {
-     "kind": "winget",
-     "command": "winget install --id yorukot.superfile",
-     "source": "readme",
-     "requires": [
-      "winget"
-     ],
-     "os": [
-      "windows"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "scoop",
-     "command": "scoop install superfile",
-     "source": "readme",
-     "requires": [
-      "scoop"
-     ],
-     "os": [
-      "windows"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/MHNightCat/superfile@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/MHNightCat/superfile && cd superfile",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "superfile",
-   "url": "https://github.com/yorukot/superfile",
-   "description": "Pretty fancy and modern terminal file manager",
-   "category": "File Managers",
-   "stars": 18687,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-20T05:07:46Z",
-   "homepage": "https://superfile.dev",
-   "methods": [
-    {
-     "kind": "winget",
-     "command": "winget install --id yorukot.superfile",
-     "source": "readme",
-     "requires": [
-      "winget"
-     ],
-     "os": [
-      "windows"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "scoop",
-     "command": "scoop install superfile",
-     "source": "readme",
-     "requires": [
-      "scoop"
-     ],
-     "os": [
-      "windows"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/yorukot/superfile@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/yorukot/superfile && cd superfile",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install superfile",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
-   "name": "herdr",
-   "url": "https://github.com/ogulcancelik/herdr",
-   "description": "Agent multiplexer that lives in your terminal.",
-   "category": "Development",
-   "stars": 18683,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T12:23:36Z",
-   "homepage": "https://herdr.dev",
-   "methods": [
-    {
-     "kind": "script",
-     "command": "curl -fsSL https://herdr.dev/install.sh | sh",
-     "source": "readme",
-     "requires": [
-      "curl"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install herdr",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "cargo",
-     "command": "cargo install herdr",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall herdr",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/ogulcancelik/herdr && cd herdr",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "ctop",
    "url": "https://github.com/bcicen/ctop",
    "description": "Top-like interface for container metrics",
    "category": "Docker/LXC/K8s",
-   "stars": 17791,
+   "stars": 17801,
    "language": "Go",
    "archived": false,
    "pushed_at": "2024-07-08T11:15:48Z",
@@ -5324,7 +5333,7 @@
    "url": "https://github.com/denisidoro/navi",
    "description": "An interactive cheatsheet tool for the command-line",
    "category": "Shell & Prompt",
-   "stars": 17340,
+   "stars": 17355,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-04-13T11:55:11Z",
@@ -5372,10 +5381,10 @@
    "url": "https://github.com/ranger/ranger",
    "description": "A VIM-inspired file manager for the console.",
    "category": "File Managers",
-   "stars": 17307,
+   "stars": 17314,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-12T14:08:53Z",
+   "pushed_at": "2026-07-21T17:50:13Z",
    "homepage": "https://ranger.fm",
    "methods": [
     {
@@ -5430,10 +5439,10 @@
    "url": "https://github.com/senorprogrammer/wtf",
    "description": "The personal information dashboard for your terminal.",
    "category": "Dashboards",
-   "stars": 17013,
+   "stars": 17020,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-15T23:33:17Z",
+   "pushed_at": "2026-07-26T04:41:14Z",
    "homepage": "http://wtfutil.com",
    "methods": [
     {
@@ -5488,10 +5497,10 @@
    "url": "https://github.com/lsd-rs/lsd",
    "description": "The next gen ls command",
    "category": "CLI Tools",
-   "stars": 16136,
+   "stars": 16149,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-06-03T07:05:49Z",
+   "pushed_at": "2026-07-25T17:02:07Z",
    "methods": [
     {
      "kind": "cargo",
@@ -5615,7 +5624,7 @@
    "url": "https://github.com/mikefarah/yq",
    "description": "Yq is a portable command-line YAML, JSON, XML, CSV, TOML, HCL and properties processor",
    "category": "CLI Tools",
-   "stars": 15719,
+   "stars": 15743,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-09T03:52:59Z",
@@ -5644,6 +5653,75 @@
     },
     {
      "kind": "go",
+     "command": "go install github.com/mikefarah/yq/v4@latest",
+     "source": "readme",
+     "requires": [
+      "go"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "nix",
+     "command": "nix profile install nixpkgs#yq-go",
+     "source": "readme",
+     "requires": [
+      "nix"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "pacman",
+     "command": "pacman -S go-yq",
+     "source": "readme",
+     "requires": [
+      "pacman"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "arch"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "choco",
+     "command": "choco install yq",
+     "source": "readme",
+     "requires": [
+      "choco"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "scoop",
+     "command": "scoop install main/yq",
+     "source": "readme",
+     "requires": [
+      "scoop"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "winget",
+     "command": "winget install --id MikeFarah.yq",
+     "source": "readme",
+     "requires": [
+      "winget"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
      "command": "go install github.com/mikefarah/yq@latest",
      "source": "inferred",
      "requires": [
@@ -5667,7 +5745,7 @@
    "url": "https://github.com/direnv/direnv",
    "description": "Unclutter your .profile",
    "category": "Development",
-   "stars": 15289,
+   "stars": 15308,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-03-31T18:52:06Z",
@@ -5707,7 +5785,7 @@
    "url": "https://github.com/muesli/duf",
    "description": "Disk Usage/Free Utility - a better 'df' alternative",
    "category": "Dashboards",
-   "stars": 15207,
+   "stars": 15219,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-01-13T11:07:14Z",
@@ -5789,6 +5867,21 @@
      "note": "from README"
     },
     {
+     "kind": "eopkg",
+     "command": "eopkg it duf",
+     "source": "readme",
+     "requires": [
+      "eopkg"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "solus"
+     ],
+     "note": "from README"
+    },
+    {
      "kind": "brew",
      "command": "brew install duf",
      "source": "readme",
@@ -5803,18 +5896,6 @@
      "source": "readme",
      "requires": [
       "choco"
-     ],
-     "os": [
-      "windows"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "scoop",
-     "command": "scoop install duf",
-     "source": "readme",
-     "requires": [
-      "scoop"
      ],
      "os": [
       "windows"
@@ -5846,10 +5927,10 @@
    "url": "https://github.com/ast-grep/ast-grep",
    "description": "⚡A CLI tool for code structural search, lint and rewriting. Written in Rust",
    "category": "Development",
-   "stars": 15132,
+   "stars": 15194,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T12:57:10Z",
+   "pushed_at": "2026-07-24T14:36:21Z",
    "homepage": "https://ast-grep.github.io/",
    "methods": [
     {
@@ -5934,7 +6015,7 @@
    "url": "https://github.com/XAMPPRocky/tokei",
    "description": "Count your code, quickly.",
    "category": "Development",
-   "stars": 14699,
+   "stars": 14719,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-06T16:44:01Z",
@@ -6067,14 +6148,14 @@
    "url": "https://github.com/tomnomnom/gron",
    "description": "Make JSON greppable!",
    "category": "CLI Tools",
-   "stars": 14486,
+   "stars": 14490,
    "language": "Go",
    "archived": false,
    "pushed_at": "2025-05-31T15:00:47Z",
    "methods": [
     {
      "kind": "brew",
-     "command": "▶ brew install gron",
+     "command": "brew install gron",
      "source": "readme",
      "requires": [
       "brew"
@@ -6083,21 +6164,12 @@
     },
     {
      "kind": "go",
-     "command": "▶ go install github.com/tomnomnom/gron@latest",
+     "command": "go install github.com/tomnomnom/gron@latest",
      "source": "readme",
      "requires": [
       "go"
      ],
      "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/tomnomnom/gron@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
     },
     {
      "kind": "source",
@@ -6107,15 +6179,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install gron",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -6124,10 +6187,10 @@
    "url": "https://github.com/microsoft/edit",
    "description": "A simple text editor. Pays homage to the classic MS-DOS Editor.",
    "category": "Editors",
-   "stars": 14400,
+   "stars": 14414,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-06-30T17:29:24Z",
+   "pushed_at": "2026-07-24T22:39:03Z",
    "methods": [
     {
      "kind": "winget",
@@ -6203,7 +6266,7 @@
    "description": "Terminal UI library with rich, interactive widgets — written in Go",
    "category": "Libraries",
    "language": "Go",
-   "stars": 14007,
+   "stars": 14010,
    "archived": false,
    "pushed_at": "2026-03-16T13:00:15Z",
    "methods": [
@@ -6232,10 +6295,10 @@
    "url": "https://github.com/ClementTsang/bottom",
    "description": "A customizable graphical process/system monitor for the terminal.",
    "category": "Dashboards",
-   "stars": 13756,
+   "stars": 13786,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T07:29:20Z",
+   "pushed_at": "2026-07-26T00:59:44Z",
    "homepage": "https://bottom.pages.dev",
    "methods": [
     {
@@ -6375,7 +6438,7 @@
    "url": "https://github.com/gizak/termui",
    "description": "Golang terminal dashboard",
    "category": "Dashboards",
-   "stars": 13579,
+   "stars": 13581,
    "language": "Go",
    "archived": false,
    "pushed_at": "2025-07-10T06:33:40Z",
@@ -6405,7 +6468,7 @@
    "url": "https://github.com/cheat/cheat",
    "description": "Cheat allows you to create and view interactive cheatsheets on the command-line. It was designed to help remind nix system administrators of options for commands that they use frequently, but not frequently enough to remember.",
    "category": "CLI Tools",
-   "stars": 13398,
+   "stars": 13404,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-05-19T16:11:23Z",
@@ -6444,7 +6507,7 @@
    "url": "https://github.com/jonas/tig",
    "description": "Text-mode interface for git",
    "category": "Development",
-   "stars": 13282,
+   "stars": 13287,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-06-19T18:25:46Z",
@@ -6475,7 +6538,7 @@
    "url": "https://github.com/Canop/broot",
    "description": "A new way to see and navigate directory trees",
    "category": "File Managers",
-   "stars": 12839,
+   "stars": 12850,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-19T07:36:38Z",
@@ -6524,9 +6587,9 @@
    "description": "A TypeScript library for building terminal user interfaces (TUIs)",
    "category": "Libraries",
    "language": "TypeScript",
-   "stars": 12617,
+   "stars": 12725,
    "archived": false,
-   "pushed_at": "2026-07-18T13:04:48Z",
+   "pushed_at": "2026-07-24T22:22:22Z",
    "homepage": "https://opentui.com",
    "methods": [
     {
@@ -6563,7 +6626,7 @@
    "url": "https://github.com/orf/gping",
    "description": "Ping, but with a graph",
    "category": "Dashboards",
-   "stars": 12571,
+   "stars": 12574,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-20T10:33:09Z",
@@ -6650,11 +6713,26 @@
     {
      "kind": "cargo",
      "command": "cargo install gping",
-     "source": "inferred",
+     "source": "readme",
      "requires": [
       "cargo"
      ],
-     "note": "guessed from repo name"
+     "note": "from README"
+    },
+    {
+     "kind": "pacman",
+     "command": "pacman -S gping",
+     "source": "readme",
+     "requires": [
+      "pacman"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "arch"
+     ],
+     "note": "from README"
     },
     {
      "kind": "cargo-binstall",
@@ -6681,7 +6759,7 @@
    "url": "https://github.com/darrenburns/posting",
    "description": "A powerful HTTP client that lives in your terminal",
    "category": "Development",
-   "stars": 12154,
+   "stars": 12190,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-03-25T23:30:48Z",
@@ -6725,11 +6803,42 @@
    ]
   },
   {
+   "name": "gh-dash",
+   "url": "https://github.com/dlvhdr/gh-dash",
+   "description": "A rich terminal UI for GitHub PRs and Issues",
+   "category": "Dashboards",
+   "stars": 12142,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-15T08:49:31Z",
+   "homepage": "https://gh-dash.dev",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/dlvhdr/gh-dash@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/dlvhdr/gh-dash && cd gh-dash",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "genact",
    "url": "https://github.com/svenstaro/genact",
    "description": "🌀 A nonsense activity generator",
    "category": "Screensavers",
-   "stars": 12132,
+   "stars": 12136,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-01T11:13:57Z",
@@ -6774,42 +6883,11 @@
    ]
   },
   {
-   "name": "gh-dash",
-   "url": "https://github.com/dlvhdr/gh-dash",
-   "description": "A rich terminal UI for GitHub PRs and Issues",
-   "category": "Dashboards",
-   "stars": 12105,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-15T08:49:31Z",
-   "homepage": "https://gh-dash.dev",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/dlvhdr/gh-dash@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/dlvhdr/gh-dash && cd gh-dash",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "git-cliff",
    "url": "https://github.com/orhun/git-cliff",
    "description": "A highly customizable Changelog Generator that follows Conventional Commit specifications ⛰️",
    "category": "Development",
-   "stars": 12034,
+   "stars": 12039,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-18T16:57:58Z",
@@ -6858,7 +6936,7 @@
    "url": "https://github.com/bootandy/dust",
    "description": "A more intuitive version of du in rust",
    "category": "Dashboards",
-   "stars": 12007,
+   "stars": 12026,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-02-21T15:29:15Z",
@@ -6948,10 +7026,10 @@
    "url": "https://github.com/o2sh/onefetch",
    "description": "Command-line Git information tool",
    "category": "Development",
-   "stars": 11973,
+   "stars": 11988,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-17T15:45:28Z",
+   "pushed_at": "2026-07-25T13:05:31Z",
    "homepage": "https://onefetch.dev",
    "methods": [
     {
@@ -7040,7 +7118,7 @@
    "description": "A high-level terminal interface library for Node.js",
    "category": "Libraries",
    "language": "JavaScript",
-   "stars": 11869,
+   "stars": 11873,
    "archived": false,
    "pushed_at": "2024-03-22T10:02:56Z",
    "methods": [
@@ -7069,7 +7147,7 @@
    "url": "https://github.com/imsnif/bandwhich",
    "description": "Terminal bandwidth utilization tool",
    "category": "Dashboards",
-   "stars": 11861,
+   "stars": 11871,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-06T19:22:08Z",
@@ -7117,7 +7195,7 @@
    "url": "https://github.com/maaslalani/slides",
    "description": "A terminal based presentation tool, supporting markdown syntax.",
    "category": "Productivity",
-   "stars": 11591,
+   "stars": 11599,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-08T18:44:50Z",
@@ -7185,9 +7263,9 @@
    "description": "A .NET library for creating beautiful console applications",
    "category": "Libraries",
    "language": "C#",
-   "stars": 11551,
+   "stars": 11557,
    "archived": false,
-   "pushed_at": "2026-07-16T06:30:47Z",
+   "pushed_at": "2026-07-23T22:25:28Z",
    "homepage": "https://spectreconsole.net",
    "methods": [
     {
@@ -7202,11 +7280,33 @@
    ]
   },
   {
+   "name": "Terminal.Gui",
+   "url": "https://github.com/gui-cs/Terminal.Gui",
+   "description": "Cross-platform terminal UI toolkit for .NET",
+   "category": "Libraries",
+   "language": "C#",
+   "stars": 11133,
+   "archived": false,
+   "pushed_at": "2026-07-19T14:42:26Z",
+   "homepage": "https://tui-cs.github.io/Terminal.Gui/",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/gui-cs/Terminal.Gui && cd Terminal.Gui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "bashtop",
    "url": "https://github.com/aristocratos/bashtop",
    "description": "Resource manager written in bash",
    "category": "Dashboards",
-   "stars": 11120,
+   "stars": 11117,
    "language": "Shell",
    "archived": false,
    "pushed_at": "2023-08-21T03:58:13Z",
@@ -7270,36 +7370,14 @@
    ]
   },
   {
-   "name": "Terminal.Gui",
-   "url": "https://github.com/gui-cs/Terminal.Gui",
-   "description": "Cross-platform terminal UI toolkit for .NET",
-   "category": "Libraries",
-   "language": "C#",
-   "stars": 11118,
-   "archived": false,
-   "pushed_at": "2026-07-19T14:42:26Z",
-   "homepage": "https://tui-cs.github.io/Terminal.Gui/",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/gui-cs/Terminal.Gui && cd Terminal.Gui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "Kakoune",
    "url": "https://github.com/mawww/kakoune",
    "description": "Mawww's experiment for a better code editor",
    "category": "Editors",
-   "stars": 10998,
+   "stars": 10999,
    "language": "C++",
    "archived": false,
-   "pushed_at": "2026-07-11T21:55:42Z",
+   "pushed_at": "2026-07-23T23:04:45Z",
    "homepage": "http://kakoune.org",
    "methods": [
     {
@@ -7327,7 +7405,7 @@
    "url": "https://github.com/aristocratos/bpytop",
    "description": "A Python-based system monitor with lots of information.",
    "category": "Dashboards",
-   "stars": 10905,
+   "stars": 10907,
    "language": "Python",
    "archived": false,
    "pushed_at": "2025-06-01T20:57:08Z",
@@ -7473,7 +7551,7 @@
    "description": "Terminal user interfaces and dashboards using Rust (no longer maintained, use Ratatui instead).",
    "category": "Libraries",
    "language": "Rust",
-   "stars": 10871,
+   "stars": 10873,
    "archived": true,
    "pushed_at": "2023-08-06T07:35:02Z",
    "methods": [
@@ -7511,7 +7589,7 @@
    "url": "https://github.com/Syllo/nvtop",
    "description": "GPUs process monitoring for AMD, Intel and NVIDIA",
    "category": "Dashboards",
-   "stars": 10846,
+   "stars": 10861,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-05-06T06:41:23Z",
@@ -7605,10 +7683,10 @@
    "url": "https://github.com/siderolabs/talos",
    "description": "A Linux distro with a TUI dashboard for local and remote usage",
    "category": "Dashboards",
-   "stars": 10806,
+   "stars": 10824,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T14:16:10Z",
+   "pushed_at": "2026-07-24T16:49:06Z",
    "homepage": "https://siderolabs.com/talos-linux",
    "methods": [
     {
@@ -7637,7 +7715,7 @@
    "description": "Minimalist Go package aimed at creating Console User Interfaces",
    "category": "Libraries",
    "language": "Go",
-   "stars": 10595,
+   "stars": 10598,
    "archived": false,
    "pushed_at": "2025-05-01T12:16:55Z",
    "methods": [
@@ -7662,12 +7740,69 @@
    ]
   },
   {
+   "name": "inshellisense",
+   "url": "https://github.com/microsoft/inshellisense",
+   "description": "IDE style command line auto complete",
+   "category": "Productivity",
+   "stars": 10547,
+   "language": "TypeScript",
+   "archived": false,
+   "pushed_at": "2026-07-25T16:47:07Z",
+   "methods": [
+    {
+     "kind": "npm",
+     "command": "npm install -g @microsoft/inshellisense",
+     "source": "readme",
+     "requires": [
+      "npm"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install inshellisense",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "npm",
+     "command": "npm install -g @microsoft/inshellisense # OR brew upgrade inshellisense",
+     "source": "readme",
+     "requires": [
+      "npm"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "npm",
+     "command": "npm install -g inshellisense",
+     "source": "inferred",
+     "requires": [
+      "npm"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/microsoft/inshellisense && cd inshellisense",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "Python Prompt Toolkit",
    "url": "https://github.com/prompt-toolkit/python-prompt-toolkit",
    "description": "Library for building powerful interactive command line applications in Python",
    "category": "Libraries",
    "language": "Python",
-   "stars": 10536,
+   "stars": 10543,
    "archived": false,
    "pushed_at": "2026-05-14T09:48:59Z",
    "homepage": "https://python-prompt-toolkit.readthedocs.io/",
@@ -7707,9 +7842,9 @@
    "description": "💻 C++ Functional Terminal User Interface. ❤️",
    "category": "Libraries",
    "language": "C++",
-   "stars": 10439,
+   "stars": 10475,
    "archived": false,
-   "pushed_at": "2026-07-20T07:43:00Z",
+   "pushed_at": "2026-07-21T17:16:19Z",
    "homepage": "https://arthursonzogni.github.io/FTXUI/",
    "methods": [
     {
@@ -7728,10 +7863,10 @@
    "url": "https://github.com/hatoo/oha",
    "description": "HTTP load generator",
    "category": "Miscellaneous",
-   "stars": 10435,
+   "stars": 10446,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-11T09:13:26Z",
+   "pushed_at": "2026-07-25T06:33:14Z",
    "methods": [
     {
      "kind": "cargo",
@@ -7767,7 +7902,7 @@
    "url": "https://github.com/sharkdp/hexyl",
    "description": "A command-line hex viewer",
    "category": "Miscellaneous",
-   "stars": 10230,
+   "stars": 10237,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-04-30T08:24:07Z",
@@ -7917,68 +8052,11 @@
    ]
   },
   {
-   "name": "inshellisense",
-   "url": "https://github.com/microsoft/inshellisense",
-   "description": "IDE style command line auto complete",
-   "category": "Productivity",
-   "stars": 10158,
-   "language": "TypeScript",
-   "archived": false,
-   "pushed_at": "2026-07-18T18:32:16Z",
-   "methods": [
-    {
-     "kind": "npm",
-     "command": "npm install -g @microsoft/inshellisense",
-     "source": "readme",
-     "requires": [
-      "npm"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install inshellisense",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "npm",
-     "command": "npm install -g @microsoft/inshellisense # OR brew upgrade inshellisense",
-     "source": "readme",
-     "requires": [
-      "npm"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "npm",
-     "command": "npm install -g inshellisense",
-     "source": "inferred",
-     "requires": [
-      "npm"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/microsoft/inshellisense && cd inshellisense",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "termshark",
    "url": "https://github.com/gcla/termshark",
    "description": "Terminal UI for tshark",
    "category": "Miscellaneous",
-   "stars": 9942,
+   "stars": 9948,
    "language": "Go",
    "archived": false,
    "pushed_at": "2024-04-30T06:15:11Z",
@@ -8017,7 +8095,7 @@
    "url": "https://github.com/aksakalli/gtop",
    "description": "System monitoring dashboard for terminal",
    "category": "Dashboards",
-   "stars": 9922,
+   "stars": 9921,
    "language": "JavaScript",
    "archived": false,
    "pushed_at": "2025-11-06T13:55:02Z",
@@ -8056,7 +8134,7 @@
    "url": "https://github.com/gokcehan/lf",
    "description": "A terminal file manager written in Go with heavy inspiration from ranger file manager.",
    "category": "File Managers",
-   "stars": 9384,
+   "stars": 9402,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-20T02:12:42Z",
@@ -8113,7 +8191,7 @@
    "url": "https://github.com/saulpw/visidata",
    "description": "A terminal spreadsheet multitool for discovering and arranging data",
    "category": "Productivity",
-   "stars": 9191,
+   "stars": 9204,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-07-15T22:27:47Z",
@@ -8162,7 +8240,7 @@
    "url": "https://github.com/rastapasta/mapscii",
    "description": "Braille & ASCII world map renderer for your console",
    "category": "Miscellaneous",
-   "stars": 9188,
+   "stars": 9194,
    "language": "JavaScript",
    "archived": false,
    "pushed_at": "2024-11-03T16:02:52Z",
@@ -8213,7 +8291,7 @@
    "url": "https://github.com/antirez/kilo",
    "description": "A minimal but complete editor in ~1000 lines of C code.",
    "category": "Editors",
-   "stars": 9038,
+   "stars": 9050,
    "language": "C",
    "archived": false,
    "pushed_at": "2025-01-04T17:31:45Z",
@@ -8234,7 +8312,7 @@
    "url": "https://github.com/mps-youtube/mps-youtube",
    "description": "Terminal based YouTube player and downloader",
    "category": "Multimedia",
-   "stars": 8766,
+   "stars": 8767,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-03-04T18:50:04Z",
@@ -8291,7 +8369,7 @@
    "url": "https://github.com/mfontanini/presenterm",
    "description": "A markdown terminal slideshow tool",
    "category": "Productivity",
-   "stars": 8601,
+   "stars": 8635,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-22T15:43:27Z",
@@ -8331,10 +8409,10 @@
    "url": "https://github.com/boyter/scc",
    "description": "Sloc, Cloc and Code: scc is a very fast accurate code counter with complexity calculations and COCOMO estimates written in pure Go",
    "category": "Development",
-   "stars": 8552,
+   "stars": 8560,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T05:30:44Z",
+   "pushed_at": "2026-07-26T01:48:58Z",
    "methods": [
     {
      "kind": "go",
@@ -8416,6 +8494,18 @@
      "note": "from README"
     },
     {
+     "kind": "winget",
+     "command": "winget install --id benboyter.scc --source winget",
+     "source": "readme",
+     "requires": [
+      "winget"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
      "kind": "go",
      "command": "go install github.com/boyter/scc@latest",
      "source": "inferred",
@@ -8436,41 +8526,11 @@
    ]
   },
   {
-   "name": "wego",
-   "url": "https://github.com/schachmat/wego",
-   "description": "Weather app",
-   "category": "Miscellaneous",
-   "stars": 8514,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-01T14:54:07Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/schachmat/wego@latest",
-     "source": "readme",
-     "requires": [
-      "go"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/schachmat/wego && cd wego",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "Claude Code Usage Monitor",
    "url": "https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor",
    "description": "Monitor Claude token usage",
    "category": "Development",
-   "stars": 8485,
+   "stars": 8520,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-07-05T04:52:21Z",
@@ -8505,11 +8565,41 @@
    ]
   },
   {
+   "name": "wego",
+   "url": "https://github.com/schachmat/wego",
+   "description": "Weather app",
+   "category": "Miscellaneous",
+   "stars": 8512,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-01T14:54:07Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/schachmat/wego@latest",
+     "source": "readme",
+     "requires": [
+      "go"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/schachmat/wego && cd wego",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "nb",
    "url": "https://github.com/xwmx/nb",
    "description": "CLI and local web plain text note‑taking, bookmarking, and archiving with linking, tagging, filtering, search, Git versioning & syncing, Pandoc conversion, + more, in a single portable script.",
    "category": "Miscellaneous",
-   "stars": 8304,
+   "stars": 8324,
    "language": "Shell",
    "archived": false,
    "pushed_at": "2026-07-06T22:36:36Z",
@@ -8559,15 +8649,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install nb",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -8576,7 +8657,7 @@
    "url": "https://github.com/draios/sysdig",
    "description": "Root level Ncurses interface for sysdig, Linux system exploration and troubleshooting tool with first class support for containers",
    "category": "Dashboards",
-   "stars": 8271,
+   "stars": 8273,
    "language": "C++",
    "archived": false,
    "pushed_at": "2026-04-13T12:32:03Z",
@@ -8598,7 +8679,7 @@
    "url": "https://github.com/htop-dev/htop",
    "description": "Interactive text-mode process viewer for Unix systems. It aims to be a better 'top'",
    "category": "Dashboards",
-   "stars": 8192,
+   "stars": 8206,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-19T14:39:40Z",
@@ -8620,7 +8701,7 @@
    "url": "https://github.com/pemistahl/grex",
    "description": "A command-line tool and Rust library with Python bindings for generating regular expressions from user-provided test cases",
    "category": "Development",
-   "stars": 8159,
+   "stars": 8162,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-02-27T17:22:36Z",
@@ -8678,7 +8759,7 @@
    "url": "https://github.com/mmulet/term.everything",
    "description": "Run any GUI app in the terminal",
    "category": "Miscellaneous",
-   "stars": 8045,
+   "stars": 8053,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-03-18T19:19:31Z",
@@ -8708,7 +8789,7 @@
    "url": "https://github.com/ducaale/xh",
    "description": "Friendly and fast tool for sending HTTP requests",
    "category": "CLI Tools",
-   "stars": 7944,
+   "stars": 7962,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-17T15:11:52Z",
@@ -8844,10 +8925,10 @@
    "url": "https://github.com/sinelaw/fresh",
    "description": "An easy-to-use, powerful and fast terminal-based text editor.",
    "category": "Editors",
-   "stars": 7893,
+   "stars": 7945,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T15:55:22Z",
+   "pushed_at": "2026-07-25T23:09:49Z",
    "homepage": "https://getfresh.dev/",
    "methods": [
     {
@@ -8986,7 +9067,7 @@
    "url": "https://github.com/cantino/mcfly",
    "description": "Intelligent context-aware search engine for your shell history",
    "category": "Productivity",
-   "stars": 7755,
+   "stars": 7759,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-04-14T01:07:32Z",
@@ -9055,7 +9136,7 @@
    "url": "https://github.com/svenstaro/miniserve",
    "description": "🌟 For when you really just want to serve some files over HTTP right now!",
    "category": "CLI Tools",
-   "stars": 7732,
+   "stars": 7733,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-01T11:14:25Z",
@@ -9103,7 +9184,7 @@
    "url": "https://github.com/libfuse/sshfs",
    "description": "A network filesystem client to connect to SSH servers",
    "category": "CLI Tools",
-   "stars": 7566,
+   "stars": 7580,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-11T10:12:39Z",
@@ -9133,7 +9214,7 @@
    "url": "https://github.com/jart/blink",
    "description": "TUI that may be used for debugging x8664-linux or i8086 programs across platforms",
    "category": "Development",
-   "stars": 7557,
+   "stars": 7563,
    "language": "C",
    "archived": false,
    "pushed_at": "2025-12-10T18:05:00Z",
@@ -9154,7 +9235,7 @@
    "url": "https://github.com/mightymoud/sidekick",
    "description": "Bare metal to production ready in mins; your own fly server on your VPS.",
    "category": "Development",
-   "stars": 7482,
+   "stars": 7483,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-02-03T10:59:11Z",
@@ -9190,283 +9271,14 @@
    ]
   },
   {
-   "name": "sd",
-   "url": "https://github.com/chmln/sd",
-   "description": "Intuitive find & replace CLI (sed alternative)",
-   "category": "CLI Tools",
-   "stars": 7265,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-02-25T19:26:21Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install sd",
-     "source": "readme",
-     "requires": [
-      "cargo"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall sd",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/chmln/sd && cd sd",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install sd",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
-   "name": "buku",
-   "url": "https://github.com/jarun/buku",
-   "description": ":bookmark: Personal mini-web in text",
-   "category": "Productivity",
-   "stars": 7160,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2026-07-03T15:34:08Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install buku",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install buku",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/jarun/buku && cd buku",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install buku",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
-   "name": "soft-serve",
-   "url": "https://github.com/charmbracelet/soft-serve",
-   "description": "A tasty, self-hostable Git server for the command lineicecream",
-   "category": "Development",
-   "stars": 7103,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-20T09:03:02Z",
-   "methods": [
-    {
-     "kind": "brew",
-     "command": "brew install charmbracelet/tap/soft-serve",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "winget",
-     "command": "winget install charmbracelet.soft-serve",
-     "source": "readme",
-     "requires": [
-      "winget"
-     ],
-     "os": [
-      "windows"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "pacman",
-     "command": "pacman -S soft-serve",
-     "source": "readme",
-     "requires": [
-      "pacman"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "arch"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "apt",
-     "command": "sudo apt update && sudo apt install soft-serve",
-     "source": "readme",
-     "requires": [
-      "apt"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "debian"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "dnf",
-     "command": "sudo yum install soft-serve",
-     "source": "readme",
-     "requires": [
-      "dnf"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "fedora",
-      "rhel"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/charmbracelet/soft-serve/cmd/soft@latest",
-     "source": "readme",
-     "requires": [
-      "go"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/charmbracelet/soft-serve@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/charmbracelet/soft-serve && cd soft-serve",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "watchexec",
-   "url": "https://github.com/watchexec/watchexec",
-   "description": "Executes commands in response to file modifications",
-   "category": "Development",
-   "stars": 7076,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-06-19T02:40:09Z",
-   "homepage": "https://watchexec.github.io",
-   "methods": [
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall watchexec-cli",
-     "source": "readme",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "cargo",
-     "command": "cargo install --locked watchexec-cli",
-     "source": "readme",
-     "requires": [
-      "cargo"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "cargo",
-     "command": "cargo install watchexec",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall watchexec",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/watchexec/watchexec && cd watchexec",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install watchexec",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
    "name": "trippy",
    "url": "https://github.com/fujiapple852/trippy",
    "description": "A network diagnostic tool that includes functionality like mtr and more",
    "category": "Dashboards",
-   "stars": 7067,
+   "stars": 7386,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T13:56:12Z",
+   "pushed_at": "2026-07-26T04:14:33Z",
    "homepage": "https://trippy.rs",
    "methods": [
     {
@@ -9595,11 +9407,279 @@
    ]
   },
   {
+   "name": "sd",
+   "url": "https://github.com/chmln/sd",
+   "description": "Intuitive find & replace CLI (sed alternative)",
+   "category": "CLI Tools",
+   "stars": 7269,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-02-25T19:26:21Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install sd",
+     "source": "readme",
+     "requires": [
+      "cargo"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall sd",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/chmln/sd && cd sd",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install sd",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
+   "name": "buku",
+   "url": "https://github.com/jarun/buku",
+   "description": ":bookmark: Personal mini-web in text",
+   "category": "Productivity",
+   "stars": 7165,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2026-07-03T15:34:08Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install buku",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install buku",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/jarun/buku && cd buku",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install buku",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
+   "name": "soft-serve",
+   "url": "https://github.com/charmbracelet/soft-serve",
+   "description": "A tasty, self-hostable Git server for the command lineicecream",
+   "category": "Development",
+   "stars": 7112,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-20T09:03:02Z",
+   "methods": [
+    {
+     "kind": "brew",
+     "command": "brew install charmbracelet/tap/soft-serve",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "winget",
+     "command": "winget install charmbracelet.soft-serve",
+     "source": "readme",
+     "requires": [
+      "winget"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "pacman",
+     "command": "pacman -S soft-serve",
+     "source": "readme",
+     "requires": [
+      "pacman"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "arch"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "apt",
+     "command": "sudo apt update && sudo apt install soft-serve",
+     "source": "readme",
+     "requires": [
+      "apt"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "debian"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "yum",
+     "command": "sudo yum install soft-serve",
+     "source": "readme",
+     "requires": [
+      "yum"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "rhel"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/charmbracelet/soft-serve/cmd/soft@latest",
+     "source": "readme",
+     "requires": [
+      "go"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/charmbracelet/soft-serve@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/charmbracelet/soft-serve && cd soft-serve",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "watchexec",
+   "url": "https://github.com/watchexec/watchexec",
+   "description": "Executes commands in response to file modifications",
+   "category": "Development",
+   "stars": 7083,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-06-19T02:40:09Z",
+   "homepage": "https://watchexec.github.io",
+   "methods": [
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall watchexec-cli",
+     "source": "readme",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "cargo",
+     "command": "cargo install --locked watchexec-cli",
+     "source": "readme",
+     "requires": [
+      "cargo"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "cargo",
+     "command": "cargo install watchexec",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall watchexec",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/watchexec/watchexec && cd watchexec",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install watchexec",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
    "name": "spotify-player",
    "url": "https://github.com/aome510/spotify-player",
    "description": "A Spotify player in the terminal with full feature parity",
    "category": "Multimedia",
-   "stars": 6975,
+   "stars": 6999,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-20T15:00:08Z",
@@ -9689,10 +9769,10 @@
    "url": "https://github.com/hrkfdn/ncspot",
    "description": "Cross-platform ncurses Spotify client written in Rust",
    "category": "Multimedia",
-   "stars": 6710,
+   "stars": 6714,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T07:55:27Z",
+   "pushed_at": "2026-07-22T09:47:58Z",
    "methods": [
     {
      "kind": "cargo",
@@ -9737,7 +9817,7 @@
    "url": "https://github.com/ogham/dog",
    "description": "A command-line DNS client.",
    "category": "CLI Tools",
-   "stars": 6676,
+   "stars": 6675,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2024-05-29T11:36:13Z",
@@ -9786,7 +9866,7 @@
    "url": "https://github.com/erroneousboat/slack-term",
    "description": "Slack client for your terminal",
    "category": "Messaging",
-   "stars": 6603,
+   "stars": 6605,
    "language": "Go",
    "archived": false,
    "pushed_at": "2024-04-23T08:35:32Z",
@@ -9816,7 +9896,7 @@
    "url": "https://github.com/busyloop/lolcat",
    "description": "Rainbows and unicorns!",
    "category": "Screensavers",
-   "stars": 6550,
+   "stars": 6556,
    "language": "Ruby",
    "archived": false,
    "pushed_at": "2024-03-05T16:19:55Z",
@@ -9867,7 +9947,7 @@
    "url": "https://github.com/dbrgn/tealdeer",
    "description": "A very fast implementation of tldr in Rust.",
    "category": "CLI Tools",
-   "stars": 6362,
+   "stars": 6372,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-07T12:24:06Z",
@@ -9912,11 +9992,42 @@
    ]
   },
   {
+   "name": "Backlog.md",
+   "url": "https://github.com/MrLesk/Backlog.md",
+   "description": "A tool for managing project collaboration between humans and AI Agents in a git ecosystem",
+   "category": "Dashboards",
+   "stars": 6292,
+   "language": "TypeScript",
+   "archived": false,
+   "pushed_at": "2026-07-19T15:32:40Z",
+   "homepage": "https://backlog.md",
+   "methods": [
+    {
+     "kind": "npm",
+     "command": "npm install -g backlog.md",
+     "source": "inferred",
+     "requires": [
+      "npm"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/MrLesk/Backlog.md && cd Backlog.md",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "cava",
    "url": "https://github.com/karlstav/cava",
    "description": "Cross-platform Audio Visualizer",
    "category": "Miscellaneous",
-   "stars": 6278,
+   "stars": 6288,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-05T18:15:13Z",
@@ -9946,10 +10057,10 @@
    "url": "https://github.com/tconbeer/harlequin",
    "description": "The SQL IDE for Your Terminal",
    "category": "Development",
-   "stars": 6270,
+   "stars": 6284,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-20T12:06:30Z",
+   "pushed_at": "2026-07-25T00:08:44Z",
    "homepage": "https://harlequin.sh",
    "methods": [
     {
@@ -9973,37 +10084,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/tconbeer/harlequin && cd harlequin",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "Backlog.md",
-   "url": "https://github.com/MrLesk/Backlog.md",
-   "description": "A tool for managing project collaboration between humans and AI Agents in a git ecosystem",
-   "category": "Dashboards",
-   "stars": 6242,
-   "language": "TypeScript",
-   "archived": false,
-   "pushed_at": "2026-07-19T15:32:40Z",
-   "homepage": "https://backlog.md",
-   "methods": [
-    {
-     "kind": "npm",
-     "command": "npm install -g backlog.md",
-     "source": "inferred",
-     "requires": [
-      "npm"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/MrLesk/Backlog.md && cd Backlog.md",
      "source": "inferred",
      "requires": [
       "git"
@@ -10047,7 +10127,7 @@
    "url": "https://github.com/achannarasappa/ticker",
    "description": "Track stocks, crypto, and derivatives prices and positions in real time from your terminal",
    "category": "Dashboards",
-   "stars": 6152,
+   "stars": 6157,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-06-28T21:50:24Z",
@@ -10073,14 +10153,54 @@
    ]
   },
   {
+   "name": "television",
+   "url": "https://github.com/alexpasmantier/television",
+   "description": "A fast and versatile fuzzy finder TUI",
+   "category": "Productivity",
+   "stars": 6121,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-24T22:03:17Z",
+   "homepage": "https://alexpasmantier.github.io/television/",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install television",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall television",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/alexpasmantier/television && cd television",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "procs",
    "url": "https://github.com/dalance/procs",
    "description": "A modern replacement for ps written in Rust",
    "category": "Dashboards",
-   "stars": 6111,
+   "stars": 6109,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-17T20:05:12Z",
+   "pushed_at": "2026-07-22T20:05:53Z",
    "methods": [
     {
      "kind": "snap",
@@ -10203,46 +10323,6 @@
    ]
   },
   {
-   "name": "television",
-   "url": "https://github.com/alexpasmantier/television",
-   "description": "A fast and versatile fuzzy finder TUI",
-   "category": "Productivity",
-   "stars": 6110,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-18T18:56:42Z",
-   "homepage": "https://alexpasmantier.github.io/television/",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install television",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall television",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/alexpasmantier/television && cd television",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "jnv",
    "url": "https://github.com/ynqa/jnv",
    "description": "Interactive JSON filter using jq",
@@ -10250,7 +10330,7 @@
    "stars": 6076,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-04-03T09:13:20Z",
+   "pushed_at": "2026-07-25T06:21:07Z",
    "methods": [
     {
      "kind": "brew",
@@ -10304,10 +10384,10 @@
    "url": "https://github.com/GothenburgBitFactory/taskwarrior",
    "description": "Taskwarrior - Command line Task Management",
    "category": "Productivity",
-   "stars": 5965,
+   "stars": 5975,
    "language": "C++",
    "archived": false,
-   "pushed_at": "2026-07-20T12:37:34Z",
+   "pushed_at": "2026-07-25T21:11:24Z",
    "homepage": "https://taskwarrior.org",
    "methods": [
     {
@@ -10335,10 +10415,10 @@
    "url": "https://github.com/dundee/gdu",
    "description": "Fast disk usage analyzer with console interface written in Go",
    "category": "Miscellaneous",
-   "stars": 5829,
+   "stars": 5845,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-16T23:52:34Z",
+   "pushed_at": "2026-07-22T23:28:42Z",
    "methods": [
     {
      "kind": "go",
@@ -10365,10 +10445,10 @@
    "url": "https://github.com/ayntgl/discordo",
    "description": "A lightweight, secure, and feature-rich Discord terminal client",
    "category": "Messaging",
-   "stars": 5684,
+   "stars": 5691,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-19T20:03:26Z",
+   "pushed_at": "2026-07-23T18:57:43Z",
    "methods": [
     {
      "kind": "go",
@@ -10395,7 +10475,7 @@
    "url": "https://github.com/andmarti1424/sc-im",
    "description": "An ncurses spreadsheet program for terminal. Reignited version of sc",
    "category": "Productivity",
-   "stars": 5653,
+   "stars": 5657,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-20T14:41:29Z",
@@ -10417,7 +10497,7 @@
    "description": "A modern Go module to beautify console output. Featuring charts, progressbars, tables, trees, and much more! It's completely configurable and 100% cross-platform compatible.",
    "category": "Libraries",
    "language": "Go",
-   "stars": 5506,
+   "stars": 5505,
    "archived": false,
    "pushed_at": "2026-07-11T21:14:49Z",
    "homepage": "https://pterm.sh",
@@ -10447,7 +10527,7 @@
    "url": "https://github.com/PaulJuliusMartinez/jless",
    "description": "Jless is a command-line JSON viewer designed for reading, exploring, and searching through JSON data.",
    "category": "CLI Tools",
-   "stars": 5443,
+   "stars": 5442,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-07T22:15:10Z",
@@ -10526,7 +10606,7 @@
    "url": "https://github.com/knqyf263/pet",
    "description": "Simple command-line snippet manager",
    "category": "Productivity",
-   "stars": 5302,
+   "stars": 5309,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-03-13T19:12:49Z",
@@ -10616,44 +10696,14 @@
    ]
   },
   {
-   "name": "tcell",
-   "url": "https://github.com/gdamore/tcell",
-   "description": "Tcell is an alternate Go terminal package, similar in some ways to termbox, but better in others.",
-   "category": "Libraries",
-   "language": "Go",
-   "stars": 5203,
-   "archived": false,
-   "pushed_at": "2026-07-19T14:30:26Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/gdamore/tcell@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/gdamore/tcell && cd tcell",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "rainfrog",
    "url": "https://github.com/achristmascarl/rainfrog",
    "description": "A database management TUI for Postgres, MySQL, and SQLite written in Rust",
    "category": "Development",
-   "stars": 5180,
+   "stars": 5206,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-11T18:20:20Z",
+   "pushed_at": "2026-07-25T19:29:30Z",
    "homepage": "https://crates.io/crates/rainfrog",
    "methods": [
     {
@@ -10686,11 +10736,41 @@
    ]
   },
   {
+   "name": "tcell",
+   "url": "https://github.com/gdamore/tcell",
+   "description": "Tcell is an alternate Go terminal package, similar in some ways to termbox, but better in others.",
+   "category": "Libraries",
+   "language": "Go",
+   "stars": 5205,
+   "archived": false,
+   "pushed_at": "2026-07-20T20:45:12Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/gdamore/tcell@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/gdamore/tcell && cd tcell",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "cmatrix",
    "url": "https://github.com/abishekvashok/cmatrix",
    "description": "Terminal based \"The Matrix\" like implementation",
    "category": "Screensavers",
-   "stars": 5166,
+   "stars": 5177,
    "language": "C",
    "archived": false,
    "pushed_at": "2024-08-21T02:41:08Z",
@@ -10720,10 +10800,10 @@
    "url": "https://github.com/hengyoush/kyanos",
    "description": "Linux network analysis tool based on eBPF",
    "category": "Dashboards",
-   "stars": 5048,
+   "stars": 5053,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-18T21:43:56Z",
+   "pushed_at": "2026-07-24T13:37:22Z",
    "homepage": "https://kyanos.io",
    "methods": [
     {
@@ -10742,10 +10822,10 @@
    "url": "https://github.com/amanusk/s-tui",
    "description": "CPU stress and monitoring utility",
    "category": "Dashboards",
-   "stars": 5048,
+   "stars": 5053,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-16T03:59:04Z",
+   "pushed_at": "2026-07-25T12:34:07Z",
    "homepage": "https://amanusk.github.io/s-tui/",
    "methods": [
     {
@@ -10782,7 +10862,7 @@
    "url": "https://github.com/hpjansson/chafa",
    "description": "📺🗿 Terminal graphics for the 21st century.",
    "category": "Multimedia",
-   "stars": 5037,
+   "stars": 5052,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-06-22T16:49:44Z",
@@ -10813,10 +10893,10 @@
    "url": "https://github.com/unhappychoice/gitlogue",
    "description": "A TUI screensaver that visualizes Git commit history in your terminal",
    "category": "Screensavers",
-   "stars": 4862,
+   "stars": 4871,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T02:24:59Z",
+   "pushed_at": "2026-07-25T05:48:00Z",
    "methods": [
     {
      "kind": "cargo",
@@ -10852,10 +10932,10 @@
    "url": "https://github.com/rakshasa/rtorrent",
    "description": "A text-based BitTorrent client written in C++",
    "category": "Web",
-   "stars": 4818,
+   "stars": 4824,
    "language": "C++",
    "archived": false,
-   "pushed_at": "2026-07-20T06:21:32Z",
+   "pushed_at": "2026-07-25T08:18:49Z",
    "homepage": "https://github.com/rakshasa/rtorrent/wiki",
    "methods": [
     {
@@ -10874,7 +10954,7 @@
    "url": "https://github.com/clangen/musikcube",
    "description": "A cross-platform, terminal-based music player, audio engine, metadata indexer, and server in c++",
    "category": "Multimedia",
-   "stars": 4803,
+   "stars": 4806,
    "language": "C++",
    "archived": false,
    "pushed_at": "2026-03-23T02:00:57Z",
@@ -10913,11 +10993,51 @@
    ]
   },
   {
+   "name": "rustnet",
+   "url": "https://github.com/domcyrus/rustnet",
+   "description": "A cross-platform network monitoring tool with deep packet inspection",
+   "category": "Dashboards",
+   "stars": 4794,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-24T10:54:30Z",
+   "homepage": "https://github.com/domcyrus/rustnet#quick-start",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install rustnet",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall rustnet",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/domcyrus/rustnet && cd rustnet",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "xplr",
    "url": "https://github.com/sayanarijit/xplr",
    "description": "A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf.",
    "category": "Miscellaneous",
-   "stars": 4782,
+   "stars": 4788,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2025-12-24T07:06:37Z",
@@ -10962,51 +11082,11 @@
    ]
   },
   {
-   "name": "rustnet",
-   "url": "https://github.com/domcyrus/rustnet",
-   "description": "A cross-platform network monitoring tool with deep packet inspection",
-   "category": "Dashboards",
-   "stars": 4748,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T14:08:18Z",
-   "homepage": "https://github.com/domcyrus/rustnet#quick-start",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install rustnet",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall rustnet",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/domcyrus/rustnet && cd rustnet",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "vis",
    "url": "https://github.com/martanne/vis",
    "description": "A vi-like editor based on Plan 9's structural regular expressions",
    "category": "Editors",
-   "stars": 4664,
+   "stars": 4672,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-13T14:14:06Z",
@@ -11028,7 +11108,7 @@
    "description": "Blingful character graphics/TUI library for C and Python. definitely not curses.",
    "category": "Libraries",
    "language": "C",
-   "stars": 4621,
+   "stars": 4635,
    "archived": false,
    "pushed_at": "2026-05-18T14:02:16Z",
    "homepage": "https://nick-black.com/dankwiki/index.php/Notcurses",
@@ -11049,10 +11129,10 @@
    "url": "https://github.com/simonmichael/hledger",
    "description": "A fast TUI for browsing double entry bookkeeping data",
    "category": "Productivity",
-   "stars": 4588,
+   "stars": 4597,
    "language": "Haskell",
    "archived": false,
-   "pushed_at": "2026-07-20T10:33:06Z",
+   "pushed_at": "2026-07-25T07:19:53Z",
    "homepage": "https://hledger.org",
    "methods": [
     {
@@ -11071,10 +11151,10 @@
    "url": "https://github.com/x-cmd/x-cmd",
    "description": "A vast and interesting collection of tools that can then bootstrap lots of other programs / functions in a consistent and structured way.",
    "category": "Miscellaneous",
-   "stars": 4531,
+   "stars": 4545,
    "language": "Awk",
    "archived": false,
-   "pushed_at": "2026-07-20T03:45:37Z",
+   "pushed_at": "2026-07-22T07:42:10Z",
    "homepage": "https://x-cmd.com",
    "methods": [
     {
@@ -11093,7 +11173,7 @@
    "url": "https://github.com/Maxteabag/sqlit",
    "description": "A lightweight TUI for SQL databases inspired by lazygit",
    "category": "Development",
-   "stars": 4515,
+   "stars": 4523,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-07-14T19:03:44Z",
@@ -11128,142 +11208,14 @@
    ]
   },
   {
-   "name": "cointop",
-   "url": "https://github.com/miguelmota/cointop",
-   "description": "The fastest and most interactive terminal based UI application for tracking cryptocurrencies",
-   "category": "Dashboards",
-   "stars": 4400,
-   "language": "Go",
-   "archived": true,
-   "pushed_at": "2024-04-07T22:46:01Z",
-   "homepage": "https://cointop.sh",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/miguelmota/cointop@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/miguelmota/cointop && cd cointop",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "doggo",
-   "url": "https://github.com/mr-karan/doggo",
-   "description": ":dog: Command-line DNS Client for Humans. Written in Golang",
-   "category": "CLI Tools",
-   "stars": 4390,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-20T16:25:19Z",
-   "homepage": "https://doggo.mrkaran.dev/",
-   "methods": [
-    {
-     "kind": "script",
-     "command": "curl -fsSL https://raw.githubusercontent.com/mr-karan/doggo/main/install.sh | sh",
-     "source": "readme",
-     "requires": [
-      "curl"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/mr-karan/doggo/cmd/doggo@latest",
-     "source": "readme",
-     "requires": [
-      "go"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "pacman",
-     "command": "pacman -S doggo",
-     "source": "readme",
-     "requires": [
-      "pacman"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "arch"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "emerge",
-     "command": "emerge net-dns/doggo",
-     "source": "readme",
-     "requires": [
-      "emerge"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "gentoo"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install doggo",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "nix",
-     "command": "nix profile install nixpkgs#doggo",
-     "source": "readme",
-     "requires": [
-      "nix"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/mr-karan/doggo@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/mr-karan/doggo && cd doggo",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "xan",
    "url": "https://github.com/medialab/xan",
    "description": "The CSV magician",
    "category": "CLI Tools",
-   "stars": 4373,
+   "stars": 4411,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-10T09:56:44Z",
+   "pushed_at": "2026-07-21T09:09:09Z",
    "methods": [
     {
      "kind": "cargo",
@@ -11376,14 +11328,166 @@
    ]
   },
   {
+   "name": "cointop",
+   "url": "https://github.com/miguelmota/cointop",
+   "description": "The fastest and most interactive terminal based UI application for tracking cryptocurrencies",
+   "category": "Dashboards",
+   "stars": 4399,
+   "language": "Go",
+   "archived": true,
+   "pushed_at": "2024-04-07T22:46:01Z",
+   "homepage": "https://cointop.sh",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/miguelmota/cointop@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/miguelmota/cointop && cd cointop",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "doggo",
+   "url": "https://github.com/mr-karan/doggo",
+   "description": ":dog: Command-line DNS Client for Humans. Written in Golang",
+   "category": "CLI Tools",
+   "stars": 4393,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-20T16:25:19Z",
+   "homepage": "https://doggo.mrkaran.dev/",
+   "methods": [
+    {
+     "kind": "script",
+     "command": "curl -fsSL https://raw.githubusercontent.com/mr-karan/doggo/main/install.sh | sh",
+     "source": "readme",
+     "requires": [
+      "curl"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/mr-karan/doggo/cmd/doggo@latest",
+     "source": "readme",
+     "requires": [
+      "go"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "pacman",
+     "command": "pacman -S doggo",
+     "source": "readme",
+     "requires": [
+      "pacman"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "arch"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "emerge",
+     "command": "emerge net-dns/doggo",
+     "source": "readme",
+     "requires": [
+      "emerge"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "gentoo"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install doggo",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "nix",
+     "command": "nix profile install nixpkgs#doggo",
+     "source": "readme",
+     "requires": [
+      "nix"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "scoop",
+     "command": "scoop install doggo",
+     "source": "readme",
+     "requires": [
+      "scoop"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "winget",
+     "command": "winget install doggo",
+     "source": "readme",
+     "requires": [
+      "winget"
+     ],
+     "os": [
+      "windows"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/mr-karan/doggo@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/mr-karan/doggo && cd doggo",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "binsider",
    "url": "https://github.com/orhun/binsider",
    "description": "A TUI for analyzing Linux binaries.",
    "category": "Dashboards",
-   "stars": 4350,
+   "stars": 4354,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-19T00:26:02Z",
+   "pushed_at": "2026-07-26T00:29:01Z",
    "homepage": "https://binsider.dev/",
    "methods": [
     {
@@ -11420,10 +11524,10 @@
    "url": "https://github.com/topgrade-rs/topgrade",
    "description": "Upgrade all the things",
    "category": "Development",
-   "stars": 4309,
+   "stars": 4331,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T02:29:29Z",
+   "pushed_at": "2026-07-25T17:27:55Z",
    "methods": [
     {
      "kind": "cargo",
@@ -11550,10 +11654,10 @@
    "url": "https://github.com/jorgerojas26/lazysql",
    "description": "A cross-platform TUI database management tool written in Go.",
    "category": "Development",
-   "stars": 4126,
+   "stars": 4146,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-16T19:55:46Z",
+   "pushed_at": "2026-07-26T04:16:19Z",
    "methods": [
     {
      "kind": "go",
@@ -11580,7 +11684,7 @@
    "url": "https://github.com/pystardust/ytfzf",
    "description": "A POSIX script that helps you find Youtube videos (without API) or Peertube videos and opens/downloads them using mpv/youtube-dl",
    "category": "Multimedia",
-   "stars": 4115,
+   "stars": 4122,
    "language": "Shell",
    "archived": false,
    "pushed_at": "2024-09-27T07:00:01Z",
@@ -11601,7 +11705,7 @@
    "url": "https://github.com/jmacdonald/amp",
    "description": "A complete text editor for your terminal",
    "category": "Editors",
-   "stars": 4105,
+   "stars": 4106,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-06-10T02:01:13Z",
@@ -11650,7 +11754,7 @@
    "url": "https://github.com/rgburke/grv",
    "description": "Terminal interface for viewing git repositories",
    "category": "Development",
-   "stars": 4093,
+   "stars": 4094,
    "language": "Go",
    "archived": false,
    "pushed_at": "2019-05-01T20:02:46Z",
@@ -11680,7 +11784,7 @@
    "url": "https://github.com/donnemartin/haxor-news",
    "description": "Browse Hacker News like a haxor: A Hacker News command line interface (CLI)",
    "category": "Web",
-   "stars": 4085,
+   "stars": 4088,
    "language": "Python",
    "archived": false,
    "pushed_at": "2022-04-22T02:41:12Z",
@@ -11719,10 +11823,10 @@
    "url": "https://github.com/quackduck/devzat",
    "description": "Chat over SSH, written in Golang with self-hosting ability.",
    "category": "Messaging",
-   "stars": 4055,
+   "stars": 4056,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-15T14:40:32Z",
+   "pushed_at": "2026-07-23T14:04:55Z",
    "methods": [
     {
      "kind": "go",
@@ -11749,10 +11853,10 @@
    "url": "https://github.com/lirantal/dockly",
    "description": "Immersive terminal interface for managing docker containers and services",
    "category": "Docker/LXC/K8s",
-   "stars": 4027,
+   "stars": 4028,
    "language": "JavaScript",
    "archived": false,
-   "pushed_at": "2026-06-20T10:56:33Z",
+   "pushed_at": "2026-07-23T18:52:55Z",
    "homepage": "https://lirantal.github.io/dockly/",
    "methods": [
     {
@@ -11780,7 +11884,7 @@
    "url": "https://github.com/YS-L/csvlens",
    "description": "TUI CSV file viewer. It is like less but made for CSV.",
    "category": "Miscellaneous",
-   "stars": 3890,
+   "stars": 3894,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-04T16:40:19Z",
@@ -11819,10 +11923,10 @@
    "url": "https://github.com/newsboat/newsboat",
    "description": "An RSS/Atom feed reader for the text console",
    "category": "Web",
-   "stars": 3860,
+   "stars": 3866,
    "language": "C++",
    "archived": false,
-   "pushed_at": "2026-07-20T16:15:30Z",
+   "pushed_at": "2026-07-25T10:41:05Z",
    "homepage": "https://newsboat.org/",
    "methods": [
     {
@@ -11841,10 +11945,10 @@
    "url": "https://github.com/NetHack/NetHack",
    "description": "Dungeon exploration game",
    "category": "Games",
-   "stars": 3824,
+   "stars": 3833,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-12T03:15:03Z",
+   "pushed_at": "2026-07-26T01:37:42Z",
    "methods": [
     {
      "kind": "source",
@@ -11862,7 +11966,7 @@
    "url": "https://github.com/adembc/lazyssh",
    "description": "TUI SSH manager to browse, connect, and manage servers from ssh config files.",
    "category": "Productivity",
-   "stars": 3801,
+   "stars": 3823,
    "language": "Go",
    "archived": false,
    "pushed_at": "2025-10-09T20:37:29Z",
@@ -11892,7 +11996,7 @@
    "url": "https://github.com/bgreenwell/doxx",
    "description": "A TUI document viewer for Microsoft Word files",
    "category": "Productivity",
-   "stars": 3721,
+   "stars": 3727,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-20T09:09:01Z",
@@ -11932,7 +12036,7 @@
    "url": "https://github.com/kamiyaa/joshuto",
    "description": "Ranger-like terminal file manager written in Rust",
    "category": "File Managers",
-   "stars": 3720,
+   "stars": 3718,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-19T02:00:51Z",
@@ -12021,7 +12125,7 @@
    "url": "https://github.com/rs/curlie",
    "description": "The power of curl, the ease of use of httpie.",
    "category": "CLI Tools",
-   "stars": 3697,
+   "stars": 3700,
    "language": "Go",
    "archived": false,
    "pushed_at": "2025-12-07T20:14:24Z",
@@ -12082,7 +12186,7 @@
    "url": "https://github.com/Julien-cpsn/ATAC",
    "description": "A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.",
    "category": "Development",
-   "stars": 3676,
+   "stars": 3683,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-03-09T07:09:22Z",
@@ -12122,10 +12226,10 @@
    "url": "https://github.com/ouch-org/ouch",
    "description": "Painless compression and decompression in the terminal",
    "category": "CLI Tools",
-   "stars": 3669,
+   "stars": 3674,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-18T22:21:16Z",
+   "pushed_at": "2026-07-25T22:42:44Z",
    "homepage": "https://crates.io/crates/ouch",
    "methods": [
     {
@@ -12198,10 +12302,10 @@
    "url": "https://github.com/raboof/nethogs",
    "description": "'net top' tool",
    "category": "Dashboards",
-   "stars": 3659,
+   "stars": 3663,
    "language": "C++",
    "archived": false,
-   "pushed_at": "2026-07-18T23:54:18Z",
+   "pushed_at": "2026-07-23T09:45:10Z",
    "methods": [
     {
      "kind": "source",
@@ -12268,7 +12372,7 @@
    "description": "An immediate mode text-based user interface C++ library, supporting 256 ANSI colors and mouse/keyboard input.",
    "category": "Libraries",
    "language": "C++",
-   "stars": 3605,
+   "stars": 3607,
    "archived": false,
    "pushed_at": "2025-10-10T08:43:31Z",
    "homepage": "https://imtui.ggerganov.com",
@@ -12289,10 +12393,10 @@
    "url": "https://github.com/surge-downloader/surge",
    "description": "A blazing fast, beautiful TUI download manager built in Go.",
    "category": "Web",
-   "stars": 3366,
+   "stars": 3386,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-17T10:55:03Z",
+   "pushed_at": "2026-07-25T04:40:53Z",
    "homepage": "https://surgedm.github.io",
    "methods": [
     {
@@ -12320,7 +12424,7 @@
    "url": "https://github.com/batrachianai/toad",
    "description": "A unified interface for AI",
    "category": "Development",
-   "stars": 3321,
+   "stars": 3334,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-05-26T08:43:50Z",
@@ -12356,11 +12460,50 @@
    ]
   },
   {
+   "name": "Claude Code Bridge",
+   "url": "https://github.com/bfly123/claude_code_bridge",
+   "description": "Real-time multi-AI collaboration between Claude, Codex and Gemini in terminal",
+   "category": "Development",
+   "stars": 3321,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2026-07-26T05:15:26Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install claude_code_bridge",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install claude_code_bridge",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/bfly123/claude_code_bridge && cd claude_code_bridge",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "gobang",
    "url": "https://github.com/TaKO8Ki/gobang",
    "description": "A cross-platform TUI database management tool written in Rust",
    "category": "Dashboards",
-   "stars": 3307,
+   "stars": 3310,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2023-11-10T08:10:28Z",
@@ -12395,50 +12538,11 @@
    ]
   },
   {
-   "name": "Claude Code Bridge",
-   "url": "https://github.com/bfly123/claude_code_bridge",
-   "description": "Real-time multi-AI collaboration between Claude, Codex and Gemini in terminal",
-   "category": "Development",
-   "stars": 3292,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2026-07-20T09:15:27Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install claude_code_bridge",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install claude_code_bridge",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/bfly123/claude_code_bridge && cd claude_code_bridge",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "tinytetris",
    "url": "https://github.com/taylorconor/tinytetris",
    "description": "80x23 terminal tetris!",
    "category": "Games",
-   "stars": 3288,
+   "stars": 3289,
    "language": "C++",
    "archived": false,
    "pushed_at": "2024-07-09T06:30:54Z",
@@ -12459,7 +12563,7 @@
    "url": "https://github.com/moncho/dry",
    "description": "A Docker manager for the terminal",
    "category": "Docker/LXC/K8s",
-   "stars": 3266,
+   "stars": 3265,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-04-09T12:13:58Z",
@@ -12490,10 +12594,10 @@
    "url": "https://github.com/inducer/pudb",
    "description": "A console-based visual debugger for Python",
    "category": "Development",
-   "stars": 3248,
+   "stars": 3250,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-17T18:57:56Z",
+   "pushed_at": "2026-07-24T15:21:52Z",
    "homepage": "https://documen.tician.de/pudb/",
    "methods": [
     {
@@ -12530,7 +12634,7 @@
    "url": "https://github.com/atanunq/viu",
    "description": "Terminal image viewer with native support for iTerm and Kitty",
    "category": "Multimedia",
-   "stars": 3239,
+   "stars": 3243,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2025-12-15T10:20:59Z",
@@ -12593,7 +12697,7 @@
    "url": "https://github.com/Textualize/frogmouth",
    "description": "A Markdown browser for your terminal",
    "category": "Editors",
-   "stars": 3229,
+   "stars": 3235,
    "language": "Python",
    "archived": false,
    "pushed_at": "2024-08-01T06:51:47Z",
@@ -12633,10 +12737,10 @@
    "url": "https://github.com/vifm/vifm",
    "description": "A TUI file manager with vi-keybindings and other vim like behaviour.",
    "category": "File Managers",
-   "stars": 3225,
+   "stars": 3228,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-12T13:53:37Z",
+   "pushed_at": "2026-07-24T17:45:35Z",
    "homepage": "https://vifm.info",
    "methods": [
     {
@@ -12655,7 +12759,7 @@
    "url": "https://github.com/Genivia/ugrep",
    "description": "🔍 ugrep 7.8 file pattern searcher -- a user-friendly, faster, more capable grep replacement. Includes a TUI, Google-like Boolean search with AND/OR/NOT, fuzzy search, hexdumps, searches (nested) archives (zip, 7z, tar, pax, cpio), compressed files (gz, Z, bz2, lzma, xz, lz4, zstd, brotli), pdfs, docs, and more",
    "category": "CLI Tools",
-   "stars": 3205,
+   "stars": 3219,
    "language": "C++",
    "archived": false,
    "pushed_at": "2026-07-19T13:05:55Z",
@@ -12722,10 +12826,10 @@
    "url": "https://github.com/util-linux/util-linux",
    "description": "TUI partition editor included in util-linux",
    "category": "Miscellaneous",
-   "stars": 3191,
+   "stars": 3190,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-20T10:53:24Z",
+   "pushed_at": "2026-07-23T12:21:30Z",
    "homepage": "http://en.wikipedia.org/wiki/Util-linux",
    "methods": [
     {
@@ -12744,10 +12848,10 @@
    "url": "https://github.com/danvergara/dblab",
    "description": "The database client every command line junkie deserves",
    "category": "Development",
-   "stars": 3162,
+   "stars": 3170,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-16T19:56:13Z",
+   "pushed_at": "2026-07-25T23:20:12Z",
    "homepage": "https://dblab.app",
    "methods": [
     {
@@ -12775,7 +12879,7 @@
    "url": "https://github.com/lxgr-linux/pokete",
    "description": "A terminal based Pokemon like game",
    "category": "Games",
-   "stars": 3142,
+   "stars": 3144,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-05-22T17:58:25Z",
@@ -12816,7 +12920,7 @@
    "description": "A modern port of C++ Turbo Vision 2.0, cross-platform and Unicode support.",
    "category": "Libraries",
    "language": "C++",
-   "stars": 3107,
+   "stars": 3115,
    "archived": false,
    "pushed_at": "2026-05-12T16:24:35Z",
    "methods": [
@@ -12836,7 +12940,7 @@
    "url": "https://github.com/imsnif/diskonaut",
    "description": "Terminal disk space navigator",
    "category": "Miscellaneous",
-   "stars": 3092,
+   "stars": 3093,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2024-03-07T20:44:17Z",
@@ -12901,11 +13005,73 @@
    ]
   },
   {
+   "name": "psmux",
+   "url": "https://github.com/marlocarlo/psmux",
+   "description": "Tmux-compatible terminal multiplexer for Windows built in Rust with ratatui.",
+   "category": "Dashboards",
+   "stars": 3052,
+   "language": "PowerShell",
+   "archived": false,
+   "pushed_at": "2026-07-24T19:24:33Z",
+   "homepage": "https://psmux.pages.dev/",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/marlocarlo/psmux && cd psmux",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "khal",
+   "url": "https://github.com/pimutils/khal",
+   "description": "A standards based CLI calendar program, able to synchronize with CalDAV servers",
+   "category": "Productivity",
+   "stars": 3039,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2026-07-20T21:05:58Z",
+   "homepage": "https://khal.readthedocs.io/",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install khal",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install khal",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/pimutils/khal && cd khal",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "zenith",
    "url": "https://github.com/bvaisvil/zenith",
    "description": "In terminal graphical metrics for your \\nix system written in Rust",
    "category": "Dashboards",
-   "stars": 3042,
+   "stars": 3038,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-13T15:16:01Z",
@@ -12979,37 +13145,36 @@
    ]
   },
   {
-   "name": "khal",
-   "url": "https://github.com/pimutils/khal",
-   "description": "A standards based CLI calendar program, able to synchronize with CalDAV servers",
+   "name": "Tabiew",
+   "url": "https://github.com/shshemi/tabiew",
+   "description": "A lightweight app to view and query tabular data files, such as CSV, TSV, and parquet.",
    "category": "Productivity",
-   "stars": 3036,
-   "language": "Python",
+   "stars": 3025,
+   "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-13T21:37:27Z",
-   "homepage": "https://khal.readthedocs.io/",
+   "pushed_at": "2026-07-25T22:22:43Z",
    "methods": [
     {
-     "kind": "uv",
-     "command": "uv tool install khal",
+     "kind": "cargo",
+     "command": "cargo install tabiew",
      "source": "inferred",
      "requires": [
-      "uv"
+      "cargo"
      ],
      "note": "guessed from repo name"
     },
     {
-     "kind": "pipx",
-     "command": "pipx install khal",
+     "kind": "cargo-binstall",
+     "command": "cargo binstall tabiew",
      "source": "inferred",
      "requires": [
-      "pipx"
+      "cargo-binstall"
      ],
      "note": "guessed from repo name"
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/pimutils/khal && cd khal",
+     "command": "git clone https://github.com/shshemi/tabiew && cd tabiew",
      "source": "inferred",
      "requires": [
       "git"
@@ -13023,7 +13188,7 @@
    "url": "https://github.com/veeso/termscp",
    "description": "A TUI file transfer and explorer, with support for SCP/SFTP/FTP/S3.",
    "category": "Productivity",
-   "stars": 3022,
+   "stars": 3025,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-06-19T17:12:56Z",
@@ -13104,45 +13269,6 @@
    ]
   },
   {
-   "name": "Tabiew",
-   "url": "https://github.com/shshemi/tabiew",
-   "description": "A lightweight app to view and query tabular data files, such as CSV, TSV, and parquet.",
-   "category": "Productivity",
-   "stars": 3018,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-17T18:08:13Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install tabiew",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall tabiew",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/shshemi/tabiew && cd tabiew",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "urwid",
    "url": "https://github.com/urwid/urwid",
    "description": "A console user interface library for Python on Linux, OSX, Cygwin or other unix-like OS.",
@@ -13150,7 +13276,7 @@
    "language": "Python",
    "stars": 3012,
    "archived": false,
-   "pushed_at": "2026-07-20T15:20:44Z",
+   "pushed_at": "2026-07-24T10:35:37Z",
    "homepage": "urwid.org",
    "methods": [
     {
@@ -13187,7 +13313,7 @@
    "url": "https://github.com/pipeseroni/pipes.sh",
    "description": "Animated pipes terminal screensaver",
    "category": "Screensavers",
-   "stars": 2999,
+   "stars": 3000,
    "language": "Shell",
    "archived": false,
    "pushed_at": "2024-08-12T05:25:41Z",
@@ -13214,33 +13340,11 @@
    ]
   },
   {
-   "name": "psmux",
-   "url": "https://github.com/marlocarlo/psmux",
-   "description": "Tmux-compatible terminal multiplexer for Windows built in Rust with ratatui.",
-   "category": "Dashboards",
-   "stars": 2992,
-   "language": "PowerShell",
-   "archived": false,
-   "pushed_at": "2026-07-20T07:49:59Z",
-   "homepage": "https://psmux.pages.dev/",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/marlocarlo/psmux && cd psmux",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "gif-for-cli",
    "url": "https://github.com/google/gif-for-cli",
    "description": "Convert a gif into ASCII",
    "category": "Miscellaneous",
-   "stars": 2952,
+   "stars": 2949,
    "language": "Python",
    "archived": true,
    "pushed_at": "2023-08-05T20:33:33Z",
@@ -13280,7 +13384,7 @@
    "url": "https://github.com/veirt/weathr",
    "description": "A terminal weather app with ASCII animations for weather visualization",
    "category": "Screensavers",
-   "stars": 2943,
+   "stars": 2949,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-06T08:23:41Z",
@@ -13315,11 +13419,33 @@
    ]
   },
   {
+   "name": "kew",
+   "url": "https://github.com/ravachol/kew",
+   "description": "A terminal music player for Linux",
+   "category": "Multimedia",
+   "stars": 2924,
+   "language": "C",
+   "archived": false,
+   "pushed_at": "2026-07-23T07:49:28Z",
+   "homepage": "https://kewplayer.com",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/ravachol/kew && cd kew",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "kmon",
    "url": "https://github.com/orhun/kmon",
    "description": "Linux Kernel Manager and Activity Monitor",
    "category": "Dashboards",
-   "stars": 2914,
+   "stars": 2918,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-20T15:23:56Z",
@@ -13355,33 +13481,11 @@
    ]
   },
   {
-   "name": "kew",
-   "url": "https://github.com/ravachol/kew",
-   "description": "A terminal music player for Linux",
-   "category": "Multimedia",
-   "stars": 2910,
-   "language": "C",
-   "archived": false,
-   "pushed_at": "2026-07-20T13:34:43Z",
-   "homepage": "https://kewplayer.com",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/ravachol/kew && cd kew",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "bluetui",
    "url": "https://github.com/pythops/bluetui",
    "description": "A TUI for managing bluetooth devices.",
    "category": "Miscellaneous",
-   "stars": 2896,
+   "stars": 2903,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-17T18:02:57Z",
@@ -13420,7 +13524,7 @@
    "url": "https://github.com/EnhancedJax/Bagels",
    "description": "TUI expense tracker",
    "category": "Productivity",
-   "stars": 2838,
+   "stars": 2848,
    "language": "Python",
    "archived": false,
    "pushed_at": "2025-07-06T01:56:26Z",
@@ -13459,7 +13563,7 @@
    "url": "https://github.com/noahgorstein/jqp",
    "description": "A TUI playground to experiment with jq",
    "category": "Development",
-   "stars": 2822,
+   "stars": 2824,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-02-06T11:05:25Z",
@@ -13485,32 +13589,11 @@
    ]
   },
   {
-   "name": "patat",
-   "url": "https://github.com/jaspervdj/patat",
-   "description": "Terminal-based presentations using Pandoc",
-   "category": "Productivity",
-   "stars": 2741,
-   "language": "Haskell",
-   "archived": false,
-   "pushed_at": "2026-06-25T17:50:39Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/jaspervdj/patat && cd patat",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "impala",
    "url": "https://github.com/pythops/impala",
    "description": "TUI for managing wifi",
    "category": "Miscellaneous",
-   "stars": 2735,
+   "stars": 2740,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-21T11:33:19Z",
@@ -13545,11 +13628,32 @@
    ]
   },
   {
+   "name": "patat",
+   "url": "https://github.com/jaspervdj/patat",
+   "description": "Terminal-based presentations using Pandoc",
+   "category": "Productivity",
+   "stars": 2740,
+   "language": "Haskell",
+   "archived": false,
+   "pushed_at": "2026-06-25T17:50:39Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/jaspervdj/patat && cd patat",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "gonzo",
    "url": "https://github.com/control-theory/gonzo",
    "description": "A powerful, real-time log analysis terminal UI inspired by k9s.",
    "category": "Dashboards",
-   "stars": 2727,
+   "stars": 2731,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-15T13:47:48Z",
@@ -13580,10 +13684,10 @@
    "url": "https://github.com/bjarneo/cliamp",
    "description": "Cliamp - Terminal music player inspired by winamp",
    "category": "Multimedia",
-   "stars": 2709,
+   "stars": 2726,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-17T21:32:56Z",
+   "pushed_at": "2026-07-25T08:52:20Z",
    "homepage": "http://www.cliamp.stream",
    "methods": [
     {
@@ -13636,15 +13740,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install cliamp",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -13653,10 +13748,10 @@
    "url": "https://github.com/Gaurav-Gosain/tuios",
    "description": "A TUI window manager for managing multiple terminal sessions",
    "category": "Productivity",
-   "stars": 2706,
+   "stars": 2719,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T10:56:36Z",
+   "pushed_at": "2026-07-22T14:57:11Z",
    "homepage": "https://tuios.gaurav.zip/",
    "methods": [
     {
@@ -13684,10 +13779,10 @@
    "url": "https://github.com/hzeller/timg",
    "description": "A terminal image viewer",
    "category": "Multimedia",
-   "stars": 2691,
+   "stars": 2696,
    "language": "C++",
    "archived": false,
-   "pushed_at": "2026-02-19T08:50:51Z",
+   "pushed_at": "2026-07-25T13:40:36Z",
    "methods": [
     {
      "kind": "apt",
@@ -13738,10 +13833,10 @@
    "url": "https://github.com/pvolok/mprocs",
    "description": "Run multiple commands in parallel",
    "category": "Development",
-   "stars": 2673,
+   "stars": 2677,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T07:56:54Z",
+   "pushed_at": "2026-07-20T22:02:32Z",
    "methods": [
     {
      "kind": "cargo",
@@ -13826,10 +13921,10 @@
    "url": "https://github.com/joouha/euporie",
    "description": "Jupyter notebooks in the terminal",
    "category": "Development",
-   "stars": 2611,
+   "stars": 2613,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-15T14:13:07Z",
+   "pushed_at": "2026-07-21T14:33:44Z",
    "homepage": "https://euporie.readthedocs.io",
    "methods": [
     {
@@ -13867,7 +13962,7 @@
    "description": "A Java library for creating text-based UIs, very similar to the C library curses but with more functionality.",
    "category": "Libraries",
    "language": "Java",
-   "stars": 2600,
+   "stars": 2601,
    "archived": false,
    "pushed_at": "2026-07-07T12:30:20Z",
    "methods": [
@@ -13887,7 +13982,7 @@
    "url": "https://github.com/F1bonacc1/process-compose",
    "description": "TUI for running apps and processes",
    "category": "Dashboards",
-   "stars": 2577,
+   "stars": 2600,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-11T19:35:02Z",
@@ -13918,7 +14013,7 @@
    "url": "https://github.com/pythops/oryx",
    "description": "A TUI for sniffing network traffic using eBPF",
    "category": "Dashboards",
-   "stars": 2522,
+   "stars": 2531,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-17T17:33:18Z",
@@ -13957,10 +14052,10 @@
    "url": "https://github.com/kdash-rs/kdash",
    "description": "A simple and fast dashboard for Kubernetes",
    "category": "Docker/LXC/K8s",
-   "stars": 2503,
+   "stars": 2505,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T00:23:09Z",
+   "pushed_at": "2026-07-24T00:22:36Z",
    "homepage": "https://kdash-rs.github.io",
    "methods": [
     {
@@ -13984,6 +14079,76 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/kdash-rs/kdash && cd kdash",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "below",
+   "url": "https://github.com/facebookincubator/below",
+   "description": "A time traveling resource monitor for modern Linux systems",
+   "category": "Dashboards",
+   "stars": 2482,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-24T10:02:24Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install below",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall below",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/facebookincubator/below && cd below",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "sshtron",
+   "url": "https://github.com/zachlatta/sshtron",
+   "description": "Multiplayer lightcycle game that runs through SSH",
+   "category": "Games",
+   "stars": 2482,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2023-07-17T01:48:13Z",
+   "homepage": "http://sshtron.zachlatta.com",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/zachlatta/sshtron@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/zachlatta/sshtron && cd sshtron",
      "source": "inferred",
      "requires": [
       "git"
@@ -14023,76 +14188,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/haskellcamargo/sclack && cd sclack",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "below",
-   "url": "https://github.com/facebookincubator/below",
-   "description": "A time traveling resource monitor for modern Linux systems",
-   "category": "Dashboards",
-   "stars": 2481,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-18T00:28:49Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install below",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall below",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/facebookincubator/below && cd below",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "sshtron",
-   "url": "https://github.com/zachlatta/sshtron",
-   "description": "Multiplayer lightcycle game that runs through SSH",
-   "category": "Games",
-   "stars": 2480,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2023-07-17T01:48:13Z",
-   "homepage": "http://sshtron.zachlatta.com",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/zachlatta/sshtron@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/zachlatta/sshtron && cd sshtron",
      "source": "inferred",
      "requires": [
       "git"
@@ -14145,7 +14240,7 @@
    "url": "https://github.com/TheMozg/awk-raycaster",
    "description": "Pseudo-3D shooter written completely in gawk using raycasting technique",
    "category": "Games",
-   "stars": 2470,
+   "stars": 2472,
    "language": "Awk",
    "archived": false,
    "pushed_at": "2023-01-20T20:26:06Z",
@@ -14166,10 +14261,10 @@
    "url": "https://github.com/Piebald-AI/tweakcc",
    "description": "TUI to customize your Claude Code themes, thinking verbs, and more.",
    "category": "Miscellaneous",
-   "stars": 2340,
+   "stars": 2359,
    "language": "TypeScript",
    "archived": false,
-   "pushed_at": "2026-07-20T15:41:38Z",
+   "pushed_at": "2026-07-25T19:26:47Z",
    "methods": [
     {
      "kind": "npm",
@@ -14192,11 +14287,50 @@
    ]
   },
   {
+   "name": "nomadnet",
+   "url": "https://github.com/markqvist/NomadNet",
+   "description": "Secure messaging network built on Reticulum",
+   "category": "Messaging",
+   "stars": 2324,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2026-05-28T17:27:13Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install nomadnet",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install nomadnet",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/markqvist/NomadNet && cd NomadNet",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "calcure",
    "url": "https://github.com/anufrievroman/calcure",
    "description": "Modern TUI calendar and task manager with minimal and customizable UI.",
    "category": "Productivity",
-   "stars": 2316,
+   "stars": 2319,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-06-17T05:02:27Z",
@@ -14265,50 +14399,11 @@
    ]
   },
   {
-   "name": "nomadnet",
-   "url": "https://github.com/markqvist/NomadNet",
-   "description": "Secure messaging network built on Reticulum",
-   "category": "Messaging",
-   "stars": 2307,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2026-05-28T17:27:13Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install nomadnet",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install nomadnet",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/markqvist/NomadNet && cd NomadNet",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "sheets",
    "url": "https://github.com/maaslalani/sheets",
    "description": "Terminal based spreadsheet tool",
    "category": "CLI Tools",
-   "stars": 2282,
+   "stars": 2289,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-18T20:13:03Z",
@@ -14356,7 +14451,7 @@
    "url": "https://github.com/nadrad/h-m-m",
    "description": "Hackers Mind Map",
    "category": "Productivity",
-   "stars": 2269,
+   "stars": 2274,
    "language": "PHP",
    "archived": false,
    "pushed_at": "2026-07-06T13:53:27Z",
@@ -14448,15 +14543,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install choose",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -14465,10 +14551,10 @@
    "url": "https://github.com/cyring/CoreFreq",
    "description": "CPU monitoring software designed for the 64-bits Processors",
    "category": "Dashboards",
-   "stars": 2231,
+   "stars": 2233,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-19T21:24:54Z",
+   "pushed_at": "2026-07-21T04:07:48Z",
    "homepage": "https://www.cyring.fr",
    "methods": [
     {
@@ -14487,7 +14573,7 @@
    "url": "https://github.com/maaslalani/nap",
    "description": "Code snippets in your terminal",
    "category": "Development",
-   "stars": 2211,
+   "stars": 2215,
    "language": "Go",
    "archived": false,
    "pushed_at": "2024-05-18T15:20:50Z",
@@ -14517,7 +14603,7 @@
    "url": "https://github.com/elfmz/far2l",
    "description": "Linux port of Far v2 file manager",
    "category": "File Managers",
-   "stars": 2196,
+   "stars": 2198,
    "language": "C++",
    "archived": false,
    "pushed_at": "2026-07-12T06:27:16Z",
@@ -14538,7 +14624,7 @@
    "url": "https://github.com/ifd3f/caligula",
    "description": "A user-friendly, lightweight TUI for imaging disks.",
    "category": "Miscellaneous",
-   "stars": 2159,
+   "stars": 2164,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-27T00:01:58Z",
@@ -14577,10 +14663,10 @@
    "url": "https://github.com/tramhao/termusic",
    "description": "Music Player TUI written in Rust",
    "category": "Multimedia",
-   "stars": 2149,
+   "stars": 2159,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-16T00:52:24Z",
+   "pushed_at": "2026-07-25T09:42:15Z",
    "methods": [
     {
      "kind": "cargo",
@@ -14658,7 +14744,7 @@
    "url": "https://github.com/Dr-Noob/cpufetch",
    "description": "Simple yet fancy CPU architecture fetching tool",
    "category": "Dashboards",
-   "stars": 2140,
+   "stars": 2139,
    "language": "C",
    "archived": false,
    "pushed_at": "2025-11-01T09:07:03Z",
@@ -14688,10 +14774,10 @@
    "url": "https://github.com/neurocyte/flow",
    "description": "A lightning-fast, feature-rich text editor written in Zig",
    "category": "Editors",
-   "stars": 2131,
+   "stars": 2137,
    "language": "Zig",
    "archived": false,
-   "pushed_at": "2026-07-20T10:54:14Z",
+   "pushed_at": "2026-07-24T07:25:15Z",
    "homepage": "https://flow-control.dev",
    "methods": [
     {
@@ -14710,10 +14796,10 @@
    "url": "https://github.com/stateful/runme",
    "description": "Discover and run code snippets directly from your README.md or other markdowns",
    "category": "Development",
-   "stars": 2125,
+   "stars": 2129,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-18T23:20:33Z",
+   "pushed_at": "2026-07-25T21:55:18Z",
    "homepage": "https://runme.dev",
    "methods": [
     {
@@ -14767,11 +14853,42 @@
    ]
   },
   {
+   "name": "instagram-cli",
+   "url": "https://github.com/supreme-gg-gg/instagram-cli",
+   "description": "Use Instagram from your terminal, the end of brainrot is here",
+   "category": "Messaging",
+   "stars": 2095,
+   "language": "TypeScript",
+   "archived": false,
+   "pushed_at": "2026-07-11T19:04:09Z",
+   "homepage": "https://www.npmjs.com/package/@i7m/instagram-cli",
+   "methods": [
+    {
+     "kind": "npm",
+     "command": "npm install -g instagram-cli",
+     "source": "inferred",
+     "requires": [
+      "npm"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/supreme-gg-gg/instagram-cli && cd instagram-cli",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "taskwarrior-tui",
    "url": "https://github.com/kdheepak/taskwarrior-tui",
    "description": "A Terminal User Interface for Taskwarrior",
    "category": "Productivity",
-   "stars": 2088,
+   "stars": 2093,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-19T17:25:34Z",
@@ -14798,37 +14915,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/kdheepak/taskwarrior-tui && cd taskwarrior-tui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "instagram-cli",
-   "url": "https://github.com/supreme-gg-gg/instagram-cli",
-   "description": "Use Instagram from your terminal, the end of brainrot is here",
-   "category": "Messaging",
-   "stars": 2085,
-   "language": "TypeScript",
-   "archived": false,
-   "pushed_at": "2026-07-11T19:04:09Z",
-   "homepage": "https://www.npmjs.com/package/@i7m/instagram-cli",
-   "methods": [
-    {
-     "kind": "npm",
-     "command": "npm install -g instagram-cli",
-     "source": "inferred",
-     "requires": [
-      "npm"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/supreme-gg-gg/instagram-cli && cd instagram-cli",
      "source": "inferred",
      "requires": [
       "git"
@@ -14902,7 +14988,7 @@
    "url": "https://github.com/lusingander/serie",
    "description": "A rich git commit graph",
    "category": "Development",
-   "stars": 1991,
+   "stars": 1999,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-19T09:28:47Z",
@@ -14960,7 +15046,7 @@
    "url": "https://github.com/da-luce/astroterm",
    "description": "A planetarium for your terminal! Explore stars, planets, constellations, and more",
    "category": "Screensavers",
-   "stars": 1984,
+   "stars": 1992,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-04-01T01:15:38Z",
@@ -14981,7 +15067,7 @@
    "url": "https://github.com/Macchina-CLI/macchina",
    "description": "A system information frontend with an emphasis on performance.",
    "category": "Dashboards",
-   "stars": 1954,
+   "stars": 1956,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2025-03-08T00:31:31Z",
@@ -15030,7 +15116,7 @@
    "url": "https://github.com/joehillen/sysz",
    "description": "An fzf terminal UI for systemctl",
    "category": "Dashboards",
-   "stars": 1880,
+   "stars": 1881,
    "language": "Shell",
    "archived": false,
    "pushed_at": "2024-04-22T10:35:27Z",
@@ -15051,7 +15137,7 @@
    "url": "https://github.com/itsjunetime/tdf",
    "description": "A tui-based PDF viewer",
    "category": "Multimedia",
-   "stars": 1874,
+   "stars": 1878,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-06-28T15:21:15Z",
@@ -15086,6 +15172,27 @@
    ]
   },
   {
+   "name": "nchat",
+   "url": "https://github.com/d99kris/nchat",
+   "description": "Telegram/WhatsApp client",
+   "category": "Messaging",
+   "stars": 1867,
+   "language": "C++",
+   "archived": false,
+   "pushed_at": "2026-07-25T05:53:05Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/d99kris/nchat && cd nchat",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "dyff",
    "url": "https://github.com/homeport/dyff",
    "description": "/ˈdʏf/ - diff tool for YAML files, and sometimes JSON",
@@ -15093,7 +15200,7 @@
    "stars": 1863,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-16T19:44:06Z",
+   "pushed_at": "2026-07-23T19:43:45Z",
    "methods": [
     {
      "kind": "brew",
@@ -15130,36 +15237,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install dyff",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
-   "name": "nchat",
-   "url": "https://github.com/d99kris/nchat",
-   "description": "Telegram/WhatsApp client",
-   "category": "Messaging",
-   "stars": 1857,
-   "language": "C++",
-   "archived": false,
-   "pushed_at": "2026-07-19T13:07:16Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/d99kris/nchat && cd nchat",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
     }
    ]
   },
@@ -15168,10 +15245,10 @@
    "url": "https://github.com/jbangdev/jbang",
    "description": "Unleash the power of Java - JBang Lets Students, Educators and Professional Developers create, edit and run self-contained source-only Java programs with unprecedented ease.",
    "category": "Development",
-   "stars": 1842,
+   "stars": 1845,
    "language": "Java",
    "archived": false,
-   "pushed_at": "2026-07-19T21:53:29Z",
+   "pushed_at": "2026-07-25T20:47:21Z",
    "homepage": "https://jbang.dev",
    "methods": [
     {
@@ -15215,15 +15292,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install jbang",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -15232,7 +15300,7 @@
    "url": "https://github.com/cgdb/cgdb",
    "description": "Console front-end to the GNU debugger",
    "category": "Dashboards",
-   "stars": 1832,
+   "stars": 1833,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-02-27T02:56:11Z",
@@ -15283,10 +15351,10 @@
    "url": "https://github.com/unkn0wn-root/resterm",
    "description": "A terminal client for HTTP/GraphQL/gRPC with support for WebSockets, SSE, workflows, profiling, OpenAPI and response diffs.",
    "category": "Development",
-   "stars": 1805,
+   "stars": 1816,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-18T20:35:04Z",
+   "pushed_at": "2026-07-22T20:22:04Z",
    "methods": [
     {
      "kind": "go",
@@ -15313,7 +15381,7 @@
    "url": "https://github.com/Chleba/netscanner",
    "description": "Network scanner",
    "category": "Dashboards",
-   "stars": 1795,
+   "stars": 1799,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-06T16:38:09Z",
@@ -15352,7 +15420,7 @@
    "url": "https://github.com/zee-editor/zee",
    "description": "A modern text editor for the terminal written in Rust",
    "category": "Editors",
-   "stars": 1794,
+   "stars": 1798,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2025-02-06T18:41:38Z",
@@ -15422,10 +15490,10 @@
    "url": "https://github.com/PabloLec/recoverpy",
    "description": "A TUI to recover overwritten or deleted data.",
    "category": "Miscellaneous",
-   "stars": 1778,
+   "stars": 1779,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-20T13:44:22Z",
+   "pushed_at": "2026-07-21T18:12:13Z",
    "methods": [
     {
      "kind": "uv",
@@ -15457,53 +15525,14 @@
    ]
   },
   {
-   "name": "oxker",
-   "url": "https://github.com/mrjackwills/oxker",
-   "description": "A simple tui to view & control docker containers",
-   "category": "Docker/LXC/K8s",
-   "stars": 1764,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T12:30:23Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install oxker",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall oxker",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/mrjackwills/oxker && cd oxker",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "Durdraw",
    "url": "https://github.com/cmang/durdraw",
    "description": "An ASCII, Unicode and ANSI art editor",
    "category": "Editors",
-   "stars": 1762,
+   "stars": 1769,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-20T08:56:44Z",
+   "pushed_at": "2026-07-26T00:02:38Z",
    "homepage": "http://durdraw.org",
    "methods": [
     {
@@ -15536,14 +15565,93 @@
    ]
   },
   {
+   "name": "oxker",
+   "url": "https://github.com/mrjackwills/oxker",
+   "description": "A simple tui to view & control docker containers",
+   "category": "Docker/LXC/K8s",
+   "stars": 1767,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-24T09:21:10Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install oxker",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall oxker",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/mrjackwills/oxker && cd oxker",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "macmon",
+   "url": "https://github.com/vladkens/macmon",
+   "description": "Sudoless performance monitoring for Apple Silicon processors written in Rust",
+   "category": "Dashboards",
+   "stars": 1746,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-24T01:18:18Z",
+   "homepage": "https://docs.rs/macmon",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install macmon",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall macmon",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/vladkens/macmon && cd macmon",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "gpg-tui",
    "url": "https://github.com/orhun/gpg-tui",
    "description": "A terminal user interface for GnuPG",
    "category": "Miscellaneous",
-   "stars": 1741,
+   "stars": 1743,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T11:05:03Z",
+   "pushed_at": "2026-07-22T11:04:37Z",
    "homepage": "https://blog.orhun.dev/introducing-gpg-tui/",
    "methods": [
     {
@@ -15576,45 +15684,6 @@
    ]
   },
   {
-   "name": "macmon",
-   "url": "https://github.com/vladkens/macmon",
-   "description": "Sudoless performance monitoring for Apple Silicon processors written in Rust",
-   "category": "Dashboards",
-   "stars": 1736,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-06-09T20:53:57Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install macmon",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall macmon",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/vladkens/macmon && cd macmon",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "tizonia-openmax-il",
    "url": "https://github.com/tizonia/tizonia-openmax-il",
    "description": "Command-line cloud music player for Linux with support for Spotify, Google Play Music, YouTube, SoundCloud, Dirble, Plex servers and Chromecast devices",
@@ -15622,7 +15691,7 @@
    "stars": 1731,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-06T23:39:00Z",
+   "pushed_at": "2026-07-24T18:33:02Z",
    "homepage": "https://tizonia.org",
    "methods": [
     {
@@ -15641,10 +15710,10 @@
    "url": "https://github.com/tulir/gomuks",
    "description": "Matrix client",
    "category": "Messaging",
-   "stars": 1694,
+   "stars": 1696,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T15:39:06Z",
+   "pushed_at": "2026-07-25T18:49:32Z",
    "homepage": "https://gomuks.app",
    "methods": [
     {
@@ -15672,10 +15741,10 @@
    "url": "https://github.com/dustinkirkland/byobu",
    "description": "Text window manager, shell multiplexer, integrated DevOps environment",
    "category": "Productivity",
-   "stars": 1673,
+   "stars": 1677,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-17T17:53:24Z",
+   "pushed_at": "2026-07-25T17:26:50Z",
    "homepage": "https://byobu.org",
    "methods": [
     {
@@ -15721,10 +15790,10 @@
    "url": "https://github.com/whyisdifficult/jiratui",
    "description": "A TUI for interacting with Atlassian Jira directly from your shell",
    "category": "Productivity",
-   "stars": 1660,
+   "stars": 1663,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-20T14:42:52Z",
+   "pushed_at": "2026-07-25T16:01:25Z",
    "homepage": "https://jiratui.sh/",
    "methods": [
     {
@@ -15761,7 +15830,7 @@
    "url": "https://github.com/awslabs/eks-node-viewer/",
    "description": "Visualizing dynamic node usage within a kubernetes cluster",
    "category": "Docker/LXC/K8s",
-   "stars": 1634,
+   "stars": 1633,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-13T19:43:12Z",
@@ -15787,32 +15856,11 @@
    ]
   },
   {
-   "name": "Gameboy Emulator",
-   "url": "https://github.com/gabrielrcouto/php-terminal-gameboy-emulator",
-   "description": "A PHP Terminal GameBoy Emulator",
-   "category": "Games",
-   "stars": 1609,
-   "language": "PHP",
-   "archived": false,
-   "pushed_at": "2020-11-02T20:29:49Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/gabrielrcouto/php-terminal-gameboy-emulator && cd php-terminal-gameboy-emulator",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "AdGuardian-Term",
    "url": "https://github.com/lissy93/AdGuardian-Term",
    "description": "A TUI dashboard for monitoring real-time traffic from an AdGuard Home instance",
    "category": "Dashboards",
-   "stars": 1589,
+   "stars": 1621,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-31T13:52:15Z",
@@ -15848,12 +15896,33 @@
    ]
   },
   {
+   "name": "Gameboy Emulator",
+   "url": "https://github.com/gabrielrcouto/php-terminal-gameboy-emulator",
+   "description": "A PHP Terminal GameBoy Emulator",
+   "category": "Games",
+   "stars": 1610,
+   "language": "PHP",
+   "archived": false,
+   "pushed_at": "2020-11-02T20:29:49Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/gabrielrcouto/php-terminal-gameboy-emulator && cd php-terminal-gameboy-emulator",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "rang",
    "url": "https://github.com/agauniyal/rang",
    "description": "A Minimal, Header only Modern C++ library for terminal goodies.",
    "category": "Libraries",
    "language": "C++",
-   "stars": 1587,
+   "stars": 1590,
    "archived": false,
    "pushed_at": "2026-05-16T15:36:28Z",
    "homepage": "https://agauniyal.github.io/rang/",
@@ -15874,7 +15943,7 @@
    "url": "https://github.com/max-niederman/ttyper",
    "description": "Terminal-based typing test",
    "category": "Miscellaneous",
-   "stars": 1566,
+   "stars": 1570,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-04-07T12:48:00Z",
@@ -15913,7 +15982,7 @@
    "url": "https://github.com/quantumsheep/sshs",
    "description": "Terminal user interface for SSH",
    "category": "Miscellaneous",
-   "stars": 1556,
+   "stars": 1561,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-09T21:36:55Z",
@@ -16021,7 +16090,7 @@
    "url": "https://github.com/matheus-git/systemd-manager-tui",
    "description": "A program for managing systemd services through a TUI.",
    "category": "Miscellaneous",
-   "stars": 1547,
+   "stars": 1550,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-03-01T18:10:24Z",
@@ -16061,7 +16130,7 @@
    "url": "https://github.com/dimonomid/nerdlog",
    "description": "Fast, remote-first, multi-host TUI log viewer",
    "category": "Dashboards",
-   "stars": 1536,
+   "stars": 1540,
    "language": "Go",
    "archived": false,
    "pushed_at": "2025-06-22T16:49:12Z",
@@ -16095,7 +16164,7 @@
    "stars": 1531,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T05:48:35Z",
+   "pushed_at": "2026-07-25T21:56:21Z",
    "homepage": "https://kftray.app/",
    "methods": [
     {
@@ -16132,7 +16201,7 @@
    "url": "https://github.com/bgreenwell/lstr",
    "description": "A fast, minimalist directory tree viewer, written in Rust.",
    "category": "CLI Tools",
-   "stars": 1524,
+   "stars": 1525,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-20T09:25:59Z",
@@ -16196,10 +16265,10 @@
    "url": "https://github.com/unhappychoice/gittype",
    "description": "A CLI code-typing game that turns your source code into typing challenges",
    "category": "Games",
-   "stars": 1515,
+   "stars": 1521,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T12:56:10Z",
+   "pushed_at": "2026-07-25T05:48:37Z",
    "methods": [
     {
      "kind": "cargo",
@@ -16315,10 +16384,10 @@
    "url": "https://github.com/dlvhdr/diffnav",
    "description": "A git diff pager based on delta but with a file tree, à la GitHub.",
    "category": "Development",
-   "stars": 1474,
+   "stars": 1479,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-15T08:49:09Z",
+   "pushed_at": "2026-07-24T10:17:01Z",
    "methods": [
     {
      "kind": "brew",
@@ -16346,15 +16415,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install diffnav",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -16363,7 +16423,7 @@
    "url": "https://github.com/bgreenwell/xleak",
    "description": "A fast terminal Excel viewer with an interactive TUI. Features full-text search, formula display, lazy loading for large files, clipboard support, and export to CSV/JSON. Built with Rust and ratatui.",
    "category": "CLI Tools",
-   "stars": 1434,
+   "stars": 1436,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-15T15:23:29Z",
@@ -16481,15 +16541,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install xleak",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -16498,7 +16549,7 @@
    "url": "https://github.com/Textualize/textual-web",
    "description": "Run TUIs and terminals in your browser",
    "category": "Web",
-   "stars": 1431,
+   "stars": 1432,
    "language": "Python",
    "archived": false,
    "pushed_at": "2024-08-30T16:00:35Z",
@@ -16537,10 +16588,10 @@
    "url": "https://github.com/tmewett/BrogueCE",
    "description": "Beautiful roguelike dungeon crawler",
    "category": "Games",
-   "stars": 1411,
+   "stars": 1416,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-06-28T21:49:37Z",
+   "pushed_at": "2026-07-23T22:25:46Z",
    "homepage": "https://sites.google.com/site/broguegame/",
    "methods": [
     {
@@ -16589,10 +16640,10 @@
    "url": "https://github.com/tgraf/bmon",
    "description": "A monitoring and debugging tool to capture networking related statistics and prepare them visually.",
    "category": "Dashboards",
-   "stars": 1375,
+   "stars": 1377,
    "language": "C",
    "archived": false,
-   "pushed_at": "2023-09-19T13:03:31Z",
+   "pushed_at": "2026-07-22T22:51:24Z",
    "methods": [
     {
      "kind": "source",
@@ -16611,9 +16662,9 @@
    "description": "Rust crate for beautiful, artisanally crafted TUIs and text-based IO, with a declarative, React-like API inspired by Ink.",
    "category": "Libraries",
    "language": "Rust",
-   "stars": 1369,
+   "stars": 1372,
    "archived": false,
-   "pushed_at": "2026-07-13T18:50:42Z",
+   "pushed_at": "2026-07-21T03:38:35Z",
    "homepage": "https://crates.io/crates/iocraft",
    "methods": [
     {
@@ -16646,32 +16697,11 @@
    ]
   },
   {
-   "name": "ttyplot",
-   "url": "https://github.com/tenox7/ttyplot",
-   "description": "A realtime plotting utility for terminals with data input from stdin/pipe.",
-   "category": "Productivity",
-   "stars": 1366,
-   "language": "C",
-   "archived": false,
-   "pushed_at": "2026-07-14T06:46:57Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/tenox7/ttyplot && cd ttyplot",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "bluetuith",
    "url": "https://github.com/darkhz/bluetuith",
    "description": "A TUI-based bluetooth connection manager, which can interact with bluetooth adapters and devices.",
    "category": "Miscellaneous",
-   "stars": 1365,
+   "stars": 1367,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-01T11:17:40Z",
@@ -16697,11 +16727,32 @@
    ]
   },
   {
+   "name": "ttyplot",
+   "url": "https://github.com/tenox7/ttyplot",
+   "description": "A realtime plotting utility for terminals with data input from stdin/pipe.",
+   "category": "Productivity",
+   "stars": 1367,
+   "language": "C",
+   "archived": false,
+   "pushed_at": "2026-07-14T06:46:57Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/tenox7/ttyplot && cd ttyplot",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "arttime",
    "url": "https://github.com/reportaman/arttime",
    "description": "An app that brings beauty of text-art together with functionality of clock, timer, and pattern-based time manager.",
    "category": "Miscellaneous",
-   "stars": 1358,
+   "stars": 1360,
    "language": "Shell",
    "archived": false,
    "pushed_at": "2026-05-10T15:28:39Z",
@@ -16722,10 +16773,10 @@
    "url": "https://github.com/lance0/ttl",
    "description": "Fast, modern traceroute with real-time TUI, per-hop stats, ASN/geo lookup, ECMP detection, and MPLS label parsing. A better mtr.",
    "category": "Dashboards",
-   "stars": 1347,
+   "stars": 1351,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-16T09:44:54Z",
+   "pushed_at": "2026-07-23T09:46:15Z",
    "methods": [
     {
      "kind": "cargo",
@@ -16791,6 +16842,15 @@
      "note": "from README"
     },
     {
+     "kind": "script",
+     "command": "curl -fsSL https://raw.githubusercontent.com/lance0/ttl/master/install.sh | sh",
+     "source": "readme",
+     "requires": [
+      "curl"
+     ],
+     "note": "from README"
+    },
+    {
      "kind": "cargo-binstall",
      "command": "cargo binstall ttl",
      "source": "inferred",
@@ -16815,10 +16875,10 @@
    "url": "https://github.com/boxdot/gurk-rs",
    "description": "Signal Messenger client for terminal",
    "category": "Messaging",
-   "stars": 1334,
+   "stars": 1341,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-19T15:22:47Z",
+   "pushed_at": "2026-07-23T10:45:10Z",
    "methods": [
     {
      "kind": "cargo",
@@ -16854,7 +16914,7 @@
    "url": "https://github.com/Lifailon/lazyjournal",
    "description": "TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering",
    "category": "Development",
-   "stars": 1324,
+   "stars": 1328,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-01T19:29:13Z",
@@ -16885,7 +16945,7 @@
    "url": "https://github.com/ihabunek/toot",
    "description": "Mastodon CLI & TUI",
    "category": "Messaging",
-   "stars": 1319,
+   "stars": 1321,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-07-04T09:27:34Z",
@@ -16920,14 +16980,44 @@
    ]
   },
   {
+   "name": "sshm",
+   "url": "https://github.com/gu1llaum-3/sshm",
+   "description": "SSH made easy and fast: browse, connect, and control from your terminal with a modern TUI",
+   "category": "Productivity",
+   "stars": 1304,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-03-18T20:07:02Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/gu1llaum-3/sshm@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/gu1llaum-3/sshm && cd sshm",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "snips.sh",
    "url": "https://github.com/robherley/snips.sh",
    "description": "✂️ passwordless, anonymous SSH-powered pastebin with a human-friendly TUI and web UI",
    "category": "Development",
-   "stars": 1287,
+   "stars": 1291,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T02:57:35Z",
+   "pushed_at": "2026-07-26T02:56:30Z",
    "homepage": "https://snips.sh",
    "methods": [
     {
@@ -16951,11 +17041,50 @@
    ]
   },
   {
+   "name": "countdown",
+   "url": "https://github.com/antonmedv/countdown",
+   "description": "Terminal countdown timer",
+   "category": "Miscellaneous",
+   "stars": 1289,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2025-02-18T14:08:04Z",
+   "methods": [
+    {
+     "kind": "brew",
+     "command": "brew install countdown",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/antonmedv/countdown@latest",
+     "source": "readme",
+     "requires": [
+      "go"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/antonmedv/countdown && cd countdown",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "terraform-tui",
    "url": "https://github.com/idoavrah/terraform-tui",
    "description": "View and interact with Terraform state",
    "category": "Development",
-   "stars": 1285,
+   "stars": 1286,
    "language": "Python",
    "archived": false,
    "pushed_at": "2024-07-09T18:55:17Z",
@@ -16991,162 +17120,14 @@
    ]
   },
   {
-   "name": "countdown",
-   "url": "https://github.com/antonmedv/countdown",
-   "description": "Terminal countdown timer",
-   "category": "Miscellaneous",
-   "stars": 1284,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2025-02-18T14:08:04Z",
-   "methods": [
-    {
-     "kind": "brew",
-     "command": "brew install countdown",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/antonmedv/countdown@latest",
-     "source": "readme",
-     "requires": [
-      "go"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/antonmedv/countdown && cd countdown",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "sshm",
-   "url": "https://github.com/gu1llaum-3/sshm",
-   "description": "SSH made easy and fast: browse, connect, and control from your terminal with a modern TUI",
-   "category": "Productivity",
-   "stars": 1271,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-03-18T20:07:02Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/gu1llaum-3/sshm@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/gu1llaum-3/sshm && cd sshm",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "nat",
-   "url": "https://github.com/willdoescode/nat",
-   "description": "Ls alternative with useful info and a splash of color 🎨",
-   "category": "CLI Tools",
-   "stars": 1264,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2021-05-28T07:12:29Z",
-   "homepage": "https://git.io/natls",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install natls",
-     "source": "readme",
-     "requires": [
-      "cargo"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install willdoescode/natls/natls",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "snap",
-     "command": "sudo snap install natls",
-     "source": "readme",
-     "requires": [
-      "snap"
-     ],
-     "os": [
-      "linux"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "cargo",
-     "command": "cargo install nat",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall nat",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/willdoescode/nat && cd nat",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install nat",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
    "name": "basalt",
    "url": "https://github.com/erikjuhani/basalt",
    "description": "TUI Application to manage Obsidian vaults and notes directly from the terminal.",
    "category": "Messaging",
-   "stars": 1261,
+   "stars": 1271,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T03:06:23Z",
+   "pushed_at": "2026-07-25T00:24:14Z",
    "homepage": "https://erikjuhani.github.io/basalt/",
    "methods": [
     {
@@ -17179,51 +17160,11 @@
    ]
   },
   {
-   "name": "intelli-shell",
-   "url": "https://github.com/lasantosr/intelli-shell",
-   "description": "Manage command templates/snippets with dynamic completions and AI integration",
-   "category": "Productivity",
-   "stars": 1252,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-06T11:27:15Z",
-   "homepage": "https://lasantosr.github.io/intelli-shell/",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install intelli-shell",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall intelli-shell",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/lasantosr/intelli-shell && cd intelli-shell",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "ghgrab",
    "url": "https://github.com/abhixdd/ghgrab",
    "description": "A simple, pretty terminal tool that lets you browse and download files from GitHub, GitLab, Codeberg, Gitea, and Forgejo without leaving your CLI.",
    "category": "Development",
-   "stars": 1252,
+   "stars": 1265,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-20T13:14:23Z",
@@ -17301,11 +17242,121 @@
    ]
   },
   {
+   "name": "nat",
+   "url": "https://github.com/willdoescode/nat",
+   "description": "Ls alternative with useful info and a splash of color 🎨",
+   "category": "CLI Tools",
+   "stars": 1261,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2021-05-28T07:12:29Z",
+   "homepage": "https://git.io/natls",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install natls",
+     "source": "readme",
+     "requires": [
+      "cargo"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install willdoescode/natls/natls",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "snap",
+     "command": "sudo snap install natls",
+     "source": "readme",
+     "requires": [
+      "snap"
+     ],
+     "os": [
+      "linux"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "cargo",
+     "command": "cargo install nat",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall nat",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/willdoescode/nat && cd nat",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "intelli-shell",
+   "url": "https://github.com/lasantosr/intelli-shell",
+   "description": "Manage command templates/snippets with dynamic completions and AI integration",
+   "category": "Productivity",
+   "stars": 1255,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-06T11:27:15Z",
+   "homepage": "https://lasantosr.github.io/intelli-shell/",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install intelli-shell",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall intelli-shell",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/lasantosr/intelli-shell && cd intelli-shell",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "wavemon",
    "url": "https://github.com/uoaerg/wavemon",
    "description": "A wireless device monitoring application",
    "category": "Miscellaneous",
-   "stars": 1222,
+   "stars": 1223,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-06-29T15:01:57Z",
@@ -17395,11 +17446,51 @@
    ]
   },
   {
+   "name": "dtop",
+   "url": "https://github.com/amir20/dtop",
+   "description": "Terminal dashboard for Docker monitoring across multiple hosts",
+   "category": "Docker/LXC/K8s",
+   "stars": 1207,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-23T23:07:21Z",
+   "homepage": "https://dtop.dev/",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install dtop",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall dtop",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/amir20/dtop && cd dtop",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "Slumber",
    "url": "https://github.com/LucasPickering/slumber",
    "description": "Terminal-based HTTP/REST client",
    "category": "Web",
-   "stars": 1203,
+   "stars": 1207,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-04T15:17:38Z",
@@ -17439,7 +17530,7 @@
    "url": "https://github.com/Julien-cpsn/desktop-tui",
    "description": "A desktop environment without graphics",
    "category": "Productivity",
-   "stars": 1196,
+   "stars": 1197,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-03-01T18:17:07Z",
@@ -17474,52 +17565,12 @@
    ]
   },
   {
-   "name": "dtop",
-   "url": "https://github.com/amir20/dtop",
-   "description": "Terminal dashboard for Docker monitoring across multiple hosts",
-   "category": "Docker/LXC/K8s",
-   "stars": 1193,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-19T00:55:00Z",
-   "homepage": "https://dtop.dev/",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install dtop",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall dtop",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/amir20/dtop && cd dtop",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "FINAL CUT",
    "url": "https://github.com/gansm/finalcut",
    "description": "C++ library for creating terminal applications with text-based widgets",
    "category": "Libraries",
    "language": "C++",
-   "stars": 1188,
+   "stars": 1191,
    "archived": false,
    "pushed_at": "2026-07-15T05:22:59Z",
    "homepage": "https://github.com/gansm/finalcut/wiki/Getting-Started#getting-started-with-the-final-cut-widget-toolkit",
@@ -17540,7 +17591,7 @@
    "url": "https://github.com/charles-001/dolphie",
    "description": "Your single pane of glass for real-time analytics into MySQL/MariaDB & ProxySQL",
    "category": "Dashboards",
-   "stars": 1187,
+   "stars": 1188,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-07-15T03:57:39Z",
@@ -17634,10 +17685,10 @@
    "url": "https://github.com/containers/podman-tui",
    "description": "TUI for Podman containers",
    "category": "Docker/LXC/K8s",
-   "stars": 1172,
+   "stars": 1179,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-16T20:32:35Z",
+   "pushed_at": "2026-07-26T02:03:41Z",
    "methods": [
     {
      "kind": "go",
@@ -17667,7 +17718,7 @@
    "language": "C++",
    "stars": 1159,
    "archived": false,
-   "pushed_at": "2026-07-19T22:11:48Z",
+   "pushed_at": "2026-07-24T20:57:44Z",
    "homepage": "https://gammasoft71.github.io/xtd",
    "methods": [
     {
@@ -17686,7 +17737,7 @@
    "url": "https://github.com/matterhorn-chat/matterhorn",
    "description": "A Mattermost terminal client.",
    "category": "Messaging",
-   "stars": 1147,
+   "stars": 1148,
    "language": "Haskell",
    "archived": false,
    "pushed_at": "2026-07-09T17:19:44Z",
@@ -17707,7 +17758,7 @@
    "url": "https://github.com/slok/grafterm",
    "description": "Metrics dashboards on terminal, a Grafana inspired terminal version",
    "category": "Dashboards",
-   "stars": 1136,
+   "stars": 1137,
    "language": "Go",
    "archived": false,
    "pushed_at": "2022-06-10T00:17:48Z",
@@ -17737,10 +17788,10 @@
    "url": "https://github.com/thomas-mauran/chess-tui",
    "description": "Play Chess in your terminal, built in rust",
    "category": "Games",
-   "stars": 1128,
+   "stars": 1133,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-18T14:07:04Z",
+   "pushed_at": "2026-07-23T10:54:44Z",
    "homepage": "https://thomas-mauran.github.io/chess-tui/",
    "methods": [
     {
@@ -17773,11 +17824,51 @@
    ]
   },
   {
+   "name": "concord",
+   "url": "https://github.com/chojs23/concord",
+   "description": "A feature-rich TUI client for Discord",
+   "category": "Messaging",
+   "stars": 1131,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-25T07:18:43Z",
+   "homepage": "https://github.com/chojs23/concord",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install concord",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall concord",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/chojs23/concord && cd concord",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "textual-paint",
    "url": "https://github.com/1j01/textual-paint",
    "description": "MS Paint in your terminal",
    "category": "Multimedia",
-   "stars": 1113,
+   "stars": 1112,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-02-21T22:00:38Z",
@@ -17817,7 +17908,7 @@
    "url": "https://github.com/vladimirvivien/ktop",
    "description": "A top-like tool for your Kubernetes clusters",
    "category": "Docker/LXC/K8s",
-   "stars": 1098,
+   "stars": 1101,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-03T04:08:53Z",
@@ -17844,11 +17935,51 @@
    ]
   },
   {
+   "name": "spotatui",
+   "url": "https://github.com/LargeModGames/spotatui",
+   "description": "Spotify client with native streaming, synced lyrics, and real-time audio visualization",
+   "category": "Multimedia",
+   "stars": 1094,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-22T22:54:23Z",
+   "homepage": "https://spotatui.com",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install spotatui",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall spotatui",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/LargeModGames/spotatui && cd spotatui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "pyradio",
    "url": "https://github.com/coderholic/pyradio",
    "description": "TUI web radio player with thousands of stations from around the world",
    "category": "Multimedia",
-   "stars": 1083,
+   "stars": 1084,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-05-07T17:00:00Z",
@@ -17888,7 +18019,7 @@
    "url": "https://github.com/viu-media/viu",
    "description": "Your browser anime experience from the terminal",
    "category": "Multimedia",
-   "stars": 1079,
+   "stars": 1081,
    "language": "Python",
    "archived": true,
    "pushed_at": "2026-05-09T11:09:28Z",
@@ -17927,7 +18058,7 @@
    "url": "https://github.com/tats/w3m",
    "description": "A text-mode WWW browser",
    "category": "Web",
-   "stars": 1074,
+   "stars": 1073,
    "language": "C",
    "archived": false,
    "pushed_at": "2024-08-19T04:03:02Z",
@@ -17949,7 +18080,7 @@
    "url": "https://github.com/blacknon/hwatch",
    "description": "A modern alternative to watch that records command output history and provides interactive diff views, scrolling, filtering, JSON logging, and hooks.",
    "category": "Dashboards",
-   "stars": 1052,
+   "stars": 1055,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-06-24T08:27:34Z",
@@ -17984,11 +18115,51 @@
    ]
   },
   {
+   "name": "bookokrat",
+   "url": "https://github.com/bugzmanov/bookokrat",
+   "description": "Full-featured EPUB books reader with Vim keybindings.",
+   "category": "Multimedia",
+   "stars": 1054,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-22T12:33:27Z",
+   "homepage": "https://bugzmanov.github.io/bookokrat/index.html",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install bookokrat",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall bookokrat",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/bugzmanov/bookokrat && cd bookokrat",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "otel-tui",
    "url": "https://github.com/ymtdzzz/otel-tui",
    "description": "A terminal OpenTelemetry viewer",
    "category": "Dashboards",
-   "stars": 1052,
+   "stars": 1053,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-13T08:44:12Z",
@@ -18014,51 +18185,11 @@
    ]
   },
   {
-   "name": "spotatui",
-   "url": "https://github.com/LargeModGames/spotatui",
-   "description": "Spotify client with native streaming, synced lyrics, and real-time audio visualization",
-   "category": "Multimedia",
-   "stars": 1052,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T15:09:21Z",
-   "homepage": "https://spotatui.com",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install spotatui",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall spotatui",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/LargeModGames/spotatui && cd spotatui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "sen",
    "url": "https://github.com/TomasTomecek/sen",
    "description": "Terminal User Interface for docker engine",
    "category": "Docker/LXC/K8s",
-   "stars": 1049,
+   "stars": 1050,
    "language": "Python",
    "archived": false,
    "pushed_at": "2025-08-12T10:45:45Z",
@@ -18093,37 +18224,18 @@
    ]
   },
   {
-   "name": "bookokrat",
-   "url": "https://github.com/bugzmanov/bookokrat",
-   "description": "Full-featured EPUB books reader with Vim keybindings.",
-   "category": "Multimedia",
-   "stars": 1049,
-   "language": "Rust",
+   "name": "atop",
+   "url": "https://github.com/Atoptool/atop/",
+   "description": "Root level system and process monitor for Linux",
+   "category": "Dashboards",
+   "stars": 1039,
+   "language": "C",
    "archived": false,
-   "pushed_at": "2026-06-25T05:22:07Z",
-   "homepage": "https://bugzmanov.github.io/bookokrat/index.html",
+   "pushed_at": "2026-07-21T07:21:47Z",
    "methods": [
     {
-     "kind": "cargo",
-     "command": "cargo install bookokrat",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall bookokrat",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
      "kind": "source",
-     "command": "git clone https://github.com/bugzmanov/bookokrat && cd bookokrat",
+     "command": "git clone https://github.com/Atoptool/atop && cd atop",
      "source": "inferred",
      "requires": [
       "git"
@@ -18133,18 +18245,28 @@
    ]
   },
   {
-   "name": "atop",
-   "url": "https://github.com/Atoptool/atop/",
-   "description": "Root level system and process monitor for Linux",
-   "category": "Dashboards",
-   "stars": 1037,
-   "language": "C",
+   "name": "matcha",
+   "url": "https://github.com/floatpane/matcha",
+   "description": "Email client",
+   "category": "Messaging",
+   "stars": 1031,
+   "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-19T08:48:55Z",
+   "pushed_at": "2026-07-24T18:18:12Z",
+   "homepage": "https://matcha.email",
    "methods": [
     {
+     "kind": "go",
+     "command": "go install github.com/floatpane/matcha@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
      "kind": "source",
-     "command": "git clone https://github.com/Atoptool/atop && cd atop",
+     "command": "git clone https://github.com/floatpane/matcha && cd matcha",
      "source": "inferred",
      "requires": [
       "git"
@@ -18193,42 +18315,11 @@
    ]
   },
   {
-   "name": "matcha",
-   "url": "https://github.com/floatpane/matcha",
-   "description": "Email client",
-   "category": "Messaging",
-   "stars": 1025,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-20T15:50:25Z",
-   "homepage": "https://matcha.email",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/floatpane/matcha@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/floatpane/matcha && cd matcha",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "clipse",
    "url": "https://github.com/savedra1/clipse",
    "description": "TUI-based clipboard manager application",
    "category": "Productivity",
-   "stars": 1020,
+   "stars": 1022,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-06-09T13:16:46Z",
@@ -18258,7 +18349,7 @@
    "url": "https://github.com/sauljabin/kaskade",
    "description": "TUI for kafka, which allows you to interact and consume topics from your terminal in style!",
    "category": "Dashboards",
-   "stars": 1019,
+   "stars": 1021,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-03-02T15:21:33Z",
@@ -18298,7 +18389,7 @@
    "url": "https://github.com/samtay/tetris",
    "description": "A terminal interface for Tetris",
    "category": "Games",
-   "stars": 1018,
+   "stars": 1021,
    "language": "Haskell",
    "archived": false,
    "pushed_at": "2025-02-27T18:29:33Z",
@@ -18347,15 +18438,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install tetris",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -18364,7 +18446,7 @@
    "url": "https://github.com/learnbyexample/TUI-apps/tree/main/SquareTicTacToe",
    "description": "Like Tic Tac Toe, but form a square with 4 corners instead of a line",
    "category": "Games",
-   "stars": 1006,
+   "stars": 1008,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-02-02T04:34:04Z",
@@ -18403,7 +18485,7 @@
    "url": "https://github.com/learnbyexample/TUI-apps",
    "description": "A TUI with tutorials and +300 exercises on python, grep, awk, sed & general terminal usage.",
    "category": "Miscellaneous",
-   "stars": 1006,
+   "stars": 1008,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-02-02T04:34:04Z",
@@ -18442,7 +18524,7 @@
    "url": "https://github.com/Owloops/updo",
    "description": "Website monitoring tool with uptime tracking, response time metrics, and SSL certificate monitoring.",
    "category": "Dashboards",
-   "stars": 1001,
+   "stars": 1003,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-05-26T08:12:19Z",
@@ -18473,7 +18555,7 @@
    "url": "https://github.com/tsowell/wiremix",
    "description": "TUI audio mixer for PipeWire similar to pavucontrol to adjust volumes, change input/output devices and their profiles",
    "category": "Multimedia",
-   "stars": 979,
+   "stars": 982,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-12T01:19:37Z",
@@ -18543,7 +18625,7 @@
    "url": "https://github.com/FedericoBruzzone/tgt",
    "description": "A TUI for Telegram written in Rust",
    "category": "Messaging",
-   "stars": 969,
+   "stars": 968,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-20T08:35:40Z",
@@ -18582,7 +18664,7 @@
    "url": "https://github.com/hanebox/ekphos",
    "description": "A fast, lightweight, markdown research tool written in rust",
    "category": "Productivity",
-   "stars": 966,
+   "stars": 967,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-06-03T11:43:47Z",
@@ -18622,10 +18704,10 @@
    "url": "https://github.com/Macmod/godap",
    "description": "A complete TUI for LDAP written in Golang",
    "category": "Miscellaneous",
-   "stars": 964,
+   "stars": 966,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-07T00:08:38Z",
+   "pushed_at": "2026-07-21T13:07:44Z",
    "methods": [
     {
      "kind": "go",
@@ -18648,163 +18730,14 @@
    ]
   },
   {
-   "name": "pls",
-   "url": "https://github.com/pls-rs/pls",
-   "description": "Pls is a prettier and powerful ls(1) for the pros.",
-   "category": "CLI Tools",
-   "stars": 957,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-14T14:05:11Z",
-   "homepage": "https://pls.cli.rs/",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install pls",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall pls",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/pls-rs/pls && cd pls",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install pls",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
-   "name": "cloudflare-speed-cli",
-   "url": "https://github.com/kavehtehrani/cloudflare-speed-cli",
-   "description": "Internet speed test via Cloudflare",
-   "category": "Web",
-   "stars": 956,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-16T07:59:41Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install cloudflare-speed-cli",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall cloudflare-speed-cli",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/kavehtehrani/cloudflare-speed-cli && cd cloudflare-speed-cli",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "dvtm",
-   "url": "https://github.com/martanne/dvtm",
-   "description": "A terminal multiplexer with dwm like window management",
-   "category": "Productivity",
-   "stars": 952,
-   "language": "C",
-   "archived": false,
-   "pushed_at": "2024-05-18T02:03:26Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/martanne/dvtm && cd dvtm",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "longbridge-terminal",
-   "url": "https://github.com/longbridge/longbridge-terminal",
-   "description": "AI-native TUI for Longbridge Securities: real-time quotes, portfolio management, and trading for HK/US/A-share/SG markets.",
-   "category": "Productivity",
-   "stars": 948,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T08:12:50Z",
-   "homepage": "https://open.longbridge.com/docs/cli",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install longbridge-terminal",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall longbridge-terminal",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/longbridge/longbridge-terminal && cd longbridge-terminal",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "flyline",
    "url": "https://github.com/HalFrgrd/flyline",
    "description": "Flyline: a Bash plugin to replace readline for a modern line editing experience: syntax highlighting, agent integration, rich prompts, tooltips, fuzzy history search, and more!",
    "category": "Productivity",
-   "stars": 937,
+   "stars": 965,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T09:29:47Z",
+   "pushed_at": "2026-07-25T22:02:21Z",
    "methods": [
     {
      "kind": "script",
@@ -18869,11 +18802,160 @@
    ]
   },
   {
+   "name": "cloudflare-speed-cli",
+   "url": "https://github.com/kavehtehrani/cloudflare-speed-cli",
+   "description": "Internet speed test via Cloudflare",
+   "category": "Web",
+   "stars": 960,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-26T04:06:46Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install cloudflare-speed-cli",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall cloudflare-speed-cli",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/kavehtehrani/cloudflare-speed-cli && cd cloudflare-speed-cli",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "pls",
+   "url": "https://github.com/pls-rs/pls",
+   "description": "Pls is a prettier and powerful ls(1) for the pros.",
+   "category": "CLI Tools",
+   "stars": 958,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-23T08:01:46Z",
+   "homepage": "https://pls.cli.rs/",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install pls",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall pls",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/pls-rs/pls && cd pls",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install pls",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
+   "name": "dvtm",
+   "url": "https://github.com/martanne/dvtm",
+   "description": "A terminal multiplexer with dwm like window management",
+   "category": "Productivity",
+   "stars": 955,
+   "language": "C",
+   "archived": false,
+   "pushed_at": "2024-05-18T02:03:26Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/martanne/dvtm && cd dvtm",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "longbridge-terminal",
+   "url": "https://github.com/longbridge/longbridge-terminal",
+   "description": "AI-native TUI for Longbridge Securities: real-time quotes, portfolio management, and trading for HK/US/A-share/SG markets.",
+   "category": "Productivity",
+   "stars": 950,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-23T05:35:35Z",
+   "homepage": "https://open.longbridge.com/docs/cli",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install longbridge-terminal",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall longbridge-terminal",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/longbridge/longbridge-terminal && cd longbridge-terminal",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "neo",
    "url": "https://github.com/st3w/neo",
    "description": "Simulates the digital rain from \"The Matrix\"",
    "category": "Screensavers",
-   "stars": 935,
+   "stars": 938,
    "language": "C++",
    "archived": false,
    "pushed_at": "2024-04-02T21:04:50Z",
@@ -18895,46 +18977,6 @@
       "brew"
      ],
      "note": "homebrew"
-    }
-   ]
-  },
-  {
-   "name": "concord",
-   "url": "https://github.com/chojs23/concord",
-   "description": "A feature-rich TUI client for Discord",
-   "category": "Messaging",
-   "stars": 932,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T14:48:04Z",
-   "homepage": "https://github.com/chojs23/concord",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install concord",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall concord",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/chojs23/concord && cd concord",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
     }
    ]
   },
@@ -18973,7 +19015,7 @@
    "url": "https://github.com/topydo/topydo",
    "description": "A powerful todo list application using the todo.txt format",
    "category": "Productivity",
-   "stars": 929,
+   "stars": 932,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-03-18T03:38:43Z",
@@ -19012,7 +19054,7 @@
    "url": "https://github.com/MidnightCommander/mc",
    "description": "GNU Midnight Commander. A free cross-platform orthodox file manager.",
    "category": "File Managers",
-   "stars": 926,
+   "stars": 930,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-19T09:35:26Z",
@@ -19030,161 +19072,11 @@
    ]
   },
   {
-   "name": "eilmeldung",
-   "url": "https://github.com/christo-auer/eilmeldung",
-   "description": "RSS reader, supporting many RSS providers, bulk-operations and configuration options.",
-   "category": "Web",
-   "stars": 913,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T10:57:16Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install eilmeldung",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall eilmeldung",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/christo-auer/eilmeldung && cd eilmeldung",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "e1s",
-   "url": "https://github.com/keidarcy/e1s",
-   "description": "TUI for managing AWS ECS resources",
-   "category": "Docker/LXC/K8s",
-   "stars": 912,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-03T01:19:30Z",
-   "homepage": "https://e1s.xingyahao.com",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/keidarcy/e1s@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/keidarcy/e1s && cd e1s",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "ducker",
-   "url": "https://github.com/robertpsoane/ducker",
-   "description": "A slightly quackers Docker TUI based on k9s",
-   "category": "Docker/LXC/K8s",
-   "stars": 909,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-05-25T18:48:05Z",
-   "homepage": "https://ducker.soane.io",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install ducker",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall ducker",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/robertpsoane/ducker && cd ducker",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "pyTermTk",
-   "url": "https://github.com/ceccopierangiolieugenio/pyTermTk",
-   "description": "Self-contained TUI library for Python with a QT-like API semantics",
-   "category": "Libraries",
-   "language": "Python",
-   "stars": 906,
-   "archived": false,
-   "pushed_at": "2026-07-07T10:02:56Z",
-   "homepage": "https://ceccopierangiolieugenio.github.io/pyTermTk-Docs/",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install pytermtk",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install pytermtk",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/ceccopierangiolieugenio/pyTermTk && cd pyTermTk",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "dnsglobe",
    "url": "https://github.com/514-labs/dnsglobe",
    "description": "Global DNS propagation checker TUI — watch a DNS record propagate across 34 public resolvers worldwide, on a world map in your terminal",
    "category": "Dashboards",
-   "stars": 903,
+   "stars": 919,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-11T20:18:03Z",
@@ -19263,32 +19155,22 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install dnsglobe",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
   {
-   "name": "manga-tui",
-   "url": "https://github.com/josueBarretogit/manga-tui",
-   "description": "Terminal-based manga reader and downloader with image rendering support",
-   "category": "Multimedia",
-   "stars": 902,
+   "name": "eilmeldung",
+   "url": "https://github.com/christo-auer/eilmeldung",
+   "description": "RSS reader, supporting many RSS providers, bulk-operations and configuration options.",
+   "category": "Web",
+   "stars": 916,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-13T23:56:59Z",
-   "homepage": "https://crates.io/crates/manga-tui",
+   "pushed_at": "2026-07-24T19:00:20Z",
    "methods": [
     {
      "kind": "cargo",
-     "command": "cargo install manga-tui",
+     "command": "cargo install eilmeldung",
      "source": "inferred",
      "requires": [
       "cargo"
@@ -19297,7 +19179,7 @@
     },
     {
      "kind": "cargo-binstall",
-     "command": "cargo binstall manga-tui",
+     "command": "cargo binstall eilmeldung",
      "source": "inferred",
      "requires": [
       "cargo-binstall"
@@ -19306,7 +19188,78 @@
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/josueBarretogit/manga-tui && cd manga-tui",
+     "command": "git clone https://github.com/christo-auer/eilmeldung && cd eilmeldung",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "ducker",
+   "url": "https://github.com/robertpsoane/ducker",
+   "description": "A slightly quackers Docker TUI based on k9s",
+   "category": "Docker/LXC/K8s",
+   "stars": 914,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-05-25T18:48:05Z",
+   "homepage": "https://ducker.soane.io",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install ducker",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall ducker",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/robertpsoane/ducker && cd ducker",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "e1s",
+   "url": "https://github.com/keidarcy/e1s",
+   "description": "TUI for managing AWS ECS resources",
+   "category": "Docker/LXC/K8s",
+   "stars": 913,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-03T01:19:30Z",
+   "homepage": "https://e1s.xingyahao.com",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/keidarcy/e1s@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/keidarcy/e1s && cd e1s",
      "source": "inferred",
      "requires": [
       "git"
@@ -19320,7 +19273,7 @@
    "url": "https://github.com/mzivic7/endcord",
    "description": "Feature rich Discord TUI client.",
    "category": "Messaging",
-   "stars": 901,
+   "stars": 913,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-07-19T22:42:05Z",
@@ -19356,11 +19309,91 @@
    ]
   },
   {
+   "name": "manga-tui",
+   "url": "https://github.com/josueBarretogit/manga-tui",
+   "description": "Terminal-based manga reader and downloader with image rendering support",
+   "category": "Multimedia",
+   "stars": 907,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-13T23:56:59Z",
+   "homepage": "https://crates.io/crates/manga-tui",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install manga-tui",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall manga-tui",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/josueBarretogit/manga-tui && cd manga-tui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "pyTermTk",
+   "url": "https://github.com/ceccopierangiolieugenio/pyTermTk",
+   "description": "Self-contained TUI library for Python with a QT-like API semantics",
+   "category": "Libraries",
+   "language": "Python",
+   "stars": 906,
+   "archived": false,
+   "pushed_at": "2026-07-23T15:18:48Z",
+   "homepage": "https://ceccopierangiolieugenio.github.io/pyTermTk-Docs/",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install pytermtk",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install pytermtk",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/ceccopierangiolieugenio/pyTermTk && cd pyTermTk",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "felix",
    "url": "https://github.com/kyoheiu/felix",
    "description": "Tui file manager with vim-like key mapping",
    "category": "File Managers",
-   "stars": 900,
+   "stars": 901,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2025-04-12T21:38:47Z",
@@ -19424,7 +19457,7 @@
    "url": "https://github.com/lusingander/stu",
    "description": "A TUI for Amazon S3",
    "category": "Development",
-   "stars": 893,
+   "stars": 896,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-04-30T23:23:01Z",
@@ -19464,7 +19497,7 @@
    "url": "https://github.com/nachoparker/dutree",
    "description": "A tool to analyze file system usage written in Rust",
    "category": "CLI Tools",
-   "stars": 875,
+   "stars": 876,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2022-06-29T08:44:36Z",
@@ -19543,7 +19576,7 @@
    "url": "https://github.com/wojciech-graj/doom-ascii",
    "description": "Text-based DOOM running in terminal.",
    "category": "Games",
-   "stars": 862,
+   "stars": 865,
    "language": "C",
    "archived": false,
    "pushed_at": "2025-07-21T12:43:25Z",
@@ -19560,11 +19593,41 @@
    ]
   },
   {
+   "name": "tufw",
+   "url": "https://github.com/peltho/tufw",
+   "description": "Terminal UI for ufw",
+   "category": "Dashboards",
+   "stars": 849,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-06-08T11:50:12Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/peltho/tufw@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/peltho/tufw && cd tufw",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "zulip-terminal",
    "url": "https://github.com/zulip/zulip-terminal",
    "description": "Official Zulip terminal client (similar to matterhorn)",
    "category": "Messaging",
-   "stars": 848,
+   "stars": 849,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-01-27T19:44:40Z",
@@ -19599,41 +19662,11 @@
    ]
   },
   {
-   "name": "tufw",
-   "url": "https://github.com/peltho/tufw",
-   "description": "Terminal UI for ufw",
-   "category": "Dashboards",
-   "stars": 847,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-06-08T11:50:12Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/peltho/tufw@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/peltho/tufw && cd tufw",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "TUIFIManager",
    "url": "https://github.com/GiorgosXou/TUIFIManager",
    "description": "A cross-platform terminal-based file manager (supports termux).",
    "category": "File Managers",
-   "stars": 823,
+   "stars": 824,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-06-30T14:07:16Z",
@@ -19672,10 +19705,10 @@
    "url": "https://github.com/0xjuanma/golazo",
    "description": "Get soccer minute-by-minute updates and finished match stats in your terminal",
    "category": "Miscellaneous",
-   "stars": 812,
+   "stars": 815,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-06T00:31:12Z",
+   "pushed_at": "2026-07-26T02:22:05Z",
    "homepage": "https://thegolazo.app",
    "methods": [
     {
@@ -19704,9 +19737,9 @@
    "description": "A .NET terminal-based GUI framework with support of XAML",
    "category": "Libraries",
    "language": "C#",
-   "stars": 809,
+   "stars": 811,
    "archived": false,
-   "pushed_at": "2026-07-11T13:18:58Z",
+   "pushed_at": "2026-07-26T03:47:07Z",
    "methods": [
     {
      "kind": "source",
@@ -19830,11 +19863,51 @@
    ]
   },
   {
+   "name": "VT Code",
+   "url": "https://github.com/vinhnx/vtcode",
+   "description": "VT Code - Semantic Coding Agent",
+   "category": "Development",
+   "stars": 777,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-26T04:59:22Z",
+   "homepage": "https://vinhnx.github.io",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install vtcode",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall vtcode",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/vinhnx/vtcode && cd vtcode",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "ytui-music",
    "url": "https://github.com/sudipghimire533/ytui-music",
    "description": "Listen to music from youtube. Configurable, minimal, lightweight, private & beautiful music client.",
    "category": "Multimedia",
-   "stars": 769,
+   "stars": 770,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2025-03-03T20:21:40Z",
@@ -19869,51 +19942,11 @@
    ]
   },
   {
-   "name": "VT Code",
-   "url": "https://github.com/vinhnx/vtcode",
-   "description": "VT Code - Semantic Coding Agent",
-   "category": "Development",
-   "stars": 758,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T10:10:58Z",
-   "homepage": "https://vinhnx.github.io",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install vtcode",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall vtcode",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/vinhnx/vtcode && cd vtcode",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "managarr",
    "url": "https://github.com/Dark-Alex-17/managarr",
    "description": "A TUI and CLI for managing your \\arr servers",
    "category": "Multimedia",
-   "stars": 748,
+   "stars": 752,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-06T14:58:06Z",
@@ -19952,10 +19985,10 @@
    "url": "https://github.com/elio-fm/elio",
    "description": "Snappy, batteries-included terminal file manager with rich previews, inline images, bulk actions, and trash support",
    "category": "File Managers",
-   "stars": 737,
+   "stars": 740,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-19T07:33:25Z",
+   "pushed_at": "2026-07-24T20:40:53Z",
    "homepage": "https://elio-fm.github.io/",
    "methods": [
     {
@@ -20057,7 +20090,7 @@
    "description": "A terminal rendering library for creating TUIs.",
    "category": "Libraries",
    "language": "C",
-   "stars": 735,
+   "stars": 737,
    "archived": false,
    "pushed_at": "2026-02-08T03:30:16Z",
    "methods": [
@@ -20077,7 +20110,7 @@
    "url": "https://github.com/Strophox/tetro-tui",
    "description": "A very configurable tetris-like, featuring ASCII particles, replays and more.",
    "category": "Games",
-   "stars": 728,
+   "stars": 732,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-06-02T14:28:56Z",
@@ -20156,10 +20189,10 @@
    "url": "https://github.com/KSXGitHub/parallel-disk-usage",
    "description": "Highly parallelized, blazing fast directory tree analyzer",
    "category": "Miscellaneous",
-   "stars": 711,
+   "stars": 713,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-18T12:31:41Z",
+   "pushed_at": "2026-07-25T21:06:24Z",
    "homepage": "https://crates.io/crates/parallel-disk-usage",
    "methods": [
     {
@@ -20229,10 +20262,10 @@
    "url": "https://github.com/ricott1/rebels-in-the-sky",
    "description": "P2P terminal game about spacepirates playing basketball across the galaxy.",
    "category": "Games",
-   "stars": 708,
+   "stars": 711,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-16T21:05:03Z",
+   "pushed_at": "2026-07-25T21:05:20Z",
    "homepage": "https://crates.io/crates/rebels",
    "methods": [
     {
@@ -20269,7 +20302,7 @@
    "url": "https://github.com/EdJoPaTo/mqttui",
    "description": "MQTT Client written in rust",
    "category": "Miscellaneous",
-   "stars": 695,
+   "stars": 702,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-12T19:16:31Z",
@@ -20308,10 +20341,10 @@
    "url": "https://github.com/xyproto/orbiton",
    "description": "Text editor limited by VT100, suitable for programming, writing git commit messages and editing Markdown",
    "category": "Editors",
-   "stars": 687,
+   "stars": 689,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T15:18:34Z",
+   "pushed_at": "2026-07-25T20:22:36Z",
    "homepage": "https://roboticoverlords.org/orbiton",
    "methods": [
     {
@@ -20339,7 +20372,7 @@
    "url": "https://github.com/leg100/pug",
    "description": "Terraform and tofu module and infrastructure management.",
    "category": "Miscellaneous",
-   "stars": 684,
+   "stars": 685,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-01-02T11:17:40Z",
@@ -20369,7 +20402,7 @@
    "url": "https://github.com/xgi/castero",
    "description": "A TUI app to listen to podcast",
    "category": "Web",
-   "stars": 682,
+   "stars": 683,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-04-21T21:18:23Z",
@@ -20404,11 +20437,51 @@
    ]
   },
   {
+   "name": "nyaa",
+   "url": "https://github.com/Beastwick18/nyaa",
+   "description": "A nyaa.si TUI for browsing and downloading torrents",
+   "category": "Web",
+   "stars": 683,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-02-28T19:38:14Z",
+   "homepage": "https://crates.io/crates/nyaa",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install nyaa",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall nyaa",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/Beastwick18/nyaa && cd nyaa",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "tetrigo",
    "url": "https://github.com/Broderick-Westrope/tetrigo",
    "description": "Play Tetris in your terminal.",
    "category": "Games",
-   "stars": 678,
+   "stars": 679,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-04-05T21:51:57Z",
@@ -20452,51 +20525,11 @@
    ]
   },
   {
-   "name": "nyaa",
-   "url": "https://github.com/Beastwick18/nyaa",
-   "description": "A nyaa.si TUI for browsing and downloading torrents",
-   "category": "Web",
-   "stars": 677,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-02-28T19:38:14Z",
-   "homepage": "https://crates.io/crates/nyaa",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install nyaa",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall nyaa",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/Beastwick18/nyaa && cd nyaa",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "tenere",
    "url": "https://github.com/pythops/tenere",
    "description": "A TUI for ChatGPT written in Rust.",
    "category": "Productivity",
-   "stars": 675,
+   "stars": 676,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-10T07:23:08Z",
@@ -20523,6 +20556,27 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/pythops/tenere && cd tenere",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "turbo",
+   "url": "https://github.com/magiblot/turbo",
+   "description": "An experimental text editor for the terminal, based on Scintilla and Turbo Vision",
+   "category": "Editors",
+   "stars": 667,
+   "language": "C++",
+   "archived": false,
+   "pushed_at": "2026-05-10T13:41:06Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/magiblot/turbo && cd turbo",
      "source": "inferred",
      "requires": [
       "git"
@@ -20571,35 +20625,14 @@
    ]
   },
   {
-   "name": "turbo",
-   "url": "https://github.com/magiblot/turbo",
-   "description": "An experimental text editor for the terminal, based on Scintilla and Turbo Vision",
-   "category": "Editors",
-   "stars": 665,
-   "language": "C++",
-   "archived": false,
-   "pushed_at": "2026-05-10T13:41:06Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/magiblot/turbo && cd turbo",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "treemd",
    "url": "https://github.com/Epistates/treemd",
    "description": "A markdown navigator with tree-based structural navigation",
    "category": "Editors",
-   "stars": 660,
+   "stars": 665,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-02T00:08:24Z",
+   "pushed_at": "2026-07-23T17:41:29Z",
    "methods": [
     {
      "kind": "cargo",
@@ -20665,7 +20698,7 @@
    "url": "https://github.com/Xithrius/twitch-tui",
    "description": "Twitch chat in the terminal",
    "category": "Messaging",
-   "stars": 627,
+   "stars": 628,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-29T01:15:41Z",
@@ -20705,10 +20738,10 @@
    "url": "https://github.com/rkd77/elinks",
    "description": "ELinks (HTTP/FTP/..) brower with mujs javascript support.",
    "category": "Web",
-   "stars": 625,
+   "stars": 626,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-20T15:13:10Z",
+   "pushed_at": "2026-07-23T06:56:40Z",
    "methods": [
     {
      "kind": "source",
@@ -20727,13 +20760,44 @@
    "description": "Comprehensive TUI library for PHP based heavily on Ratatui.",
    "category": "Libraries",
    "language": "PHP",
-   "stars": 603,
+   "stars": 605,
    "archived": false,
    "pushed_at": "2026-05-04T19:45:39Z",
    "methods": [
     {
      "kind": "source",
      "command": "git clone https://github.com/php-tui/php-tui && cd php-tui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "agent-deck",
+   "url": "https://github.com/asheshgoplani/agent-deck",
+   "description": "Terminal dashboard for managing multiple AI coding agent sessions",
+   "category": "Productivity",
+   "stars": 599,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-20T21:56:11Z",
+   "homepage": "https://discord.gg/e4xSs6NBN8",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/asheshgoplani/agent-deck@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/asheshgoplani/agent-deck && cd agent-deck",
      "source": "inferred",
      "requires": [
       "git"
@@ -20825,7 +20889,7 @@
    "url": "https://github.com/nemuTUI/nemu",
    "description": "A TUI for QEMU",
    "category": "Miscellaneous",
-   "stars": 593,
+   "stars": 595,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-06-11T11:23:44Z",
@@ -20846,7 +20910,7 @@
    "url": "https://github.com/one2nc/cloudlens",
    "description": "K9s like CLI for AWS and GCP",
    "category": "Development",
-   "stars": 593,
+   "stars": 592,
    "language": "Go",
    "archived": false,
    "pushed_at": "2024-04-20T05:24:58Z",
@@ -20887,15 +20951,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install cloudlens",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -20904,7 +20959,7 @@
    "url": "https://github.com/pimutils/todoman",
    "description": "A simple, standards-based (ics, DAV), cli task-manager",
    "category": "Productivity",
-   "stars": 587,
+   "stars": 588,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-05-25T13:27:42Z",
@@ -20947,7 +21002,7 @@
    "stars": 580,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T12:35:20Z",
+   "pushed_at": "2026-07-22T20:38:53Z",
    "homepage": "https://github.com/Harry-kp/vortix",
    "methods": [
     {
@@ -20984,7 +21039,7 @@
    "url": "https://github.com/paololazzari/play",
    "description": "A TUI playground to experiment with your favorite programs, such as grep, sed, awk, jq and yq",
    "category": "Development",
-   "stars": 577,
+   "stars": 579,
    "language": "Go",
    "archived": false,
    "pushed_at": "2025-03-28T19:04:26Z",
@@ -21014,7 +21069,7 @@
    "url": "https://github.com/ceuk/spotui",
    "description": "Spotify client written in Python",
    "category": "Multimedia",
-   "stars": 575,
+   "stars": 576,
    "language": "Python",
    "archived": false,
    "pushed_at": "2023-07-25T21:01:49Z",
@@ -21053,10 +21108,10 @@
    "url": "https://github.com/mrusme/zeit",
    "description": "A command line tool for tracking time spent on activities.",
    "category": "Productivity",
-   "stars": 567,
+   "stars": 570,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-01-09T12:07:24Z",
+   "pushed_at": "2026-07-21T07:54:28Z",
    "homepage": "https://zeit.observer",
    "methods": [
     {
@@ -21084,7 +21139,7 @@
    "url": "https://github.com/siddhantac/puffin",
    "description": "A beautiful terminal dashboard for hledger",
    "category": "Dashboards",
-   "stars": 560,
+   "stars": 563,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-03-11T15:16:44Z",
@@ -21114,7 +21169,7 @@
    "url": "https://github.com/dhonus/jellyfin-tui",
    "description": "Jellyfin client",
    "category": "Multimedia",
-   "stars": 556,
+   "stars": 560,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-13T20:22:28Z",
@@ -21140,37 +21195,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/dhonus/jellyfin-tui && cd jellyfin-tui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "agent-deck",
-   "url": "https://github.com/asheshgoplani/agent-deck",
-   "description": "Terminal dashboard for managing multiple AI coding agent sessions",
-   "category": "Productivity",
-   "stars": 551,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-19T20:30:14Z",
-   "homepage": "https://discord.gg/e4xSs6NBN8",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/asheshgoplani/agent-deck@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/asheshgoplani/agent-deck && cd agent-deck",
      "source": "inferred",
      "requires": [
       "git"
@@ -21265,7 +21289,7 @@
    "url": "https://github.com/freref/fancy-cat",
    "description": "A Lightweight terminal-based PDF reader with Vim keybindings",
    "category": "Multimedia",
-   "stars": 541,
+   "stars": 545,
    "language": "Zig",
    "archived": false,
    "pushed_at": "2026-05-24T20:20:39Z",
@@ -21286,7 +21310,7 @@
    "url": "https://github.com/maaslalani/draw",
    "description": "A simple drawing tool in the terminal.",
    "category": "Multimedia",
-   "stars": 540,
+   "stars": 541,
    "language": "Go",
    "archived": false,
    "pushed_at": "2023-12-04T19:11:03Z",
@@ -21303,6 +21327,45 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/maaslalani/draw && cd draw",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "botany",
+   "url": "https://github.com/jifunks/botany/",
+   "description": "Virtual plant buddy",
+   "category": "Games",
+   "stars": 540,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2026-07-18T17:43:28Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install botany",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install botany",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/jifunks/botany && cd botany",
      "source": "inferred",
      "requires": [
       "git"
@@ -21351,45 +21414,6 @@
    ]
   },
   {
-   "name": "botany",
-   "url": "https://github.com/jifunks/botany/",
-   "description": "Virtual plant buddy",
-   "category": "Games",
-   "stars": 536,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2026-07-18T17:43:28Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install botany",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install botany",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/jifunks/botany && cd botany",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "xytz",
    "url": "https://github.com/xdagiz/xytz",
    "description": "Beautiful TUI for downloading YouTube videos/playlists/channels.",
@@ -21397,7 +21421,7 @@
    "stars": 533,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-18T16:48:31Z",
+   "pushed_at": "2026-07-25T15:35:48Z",
    "methods": [
     {
      "kind": "go",
@@ -21445,7 +21469,7 @@
    "url": "https://github.com/RasmusLindroth/tut",
    "description": "Mastodon TUI client",
    "category": "Messaging",
-   "stars": 498,
+   "stars": 499,
    "language": "Go",
    "archived": false,
    "pushed_at": "2023-12-18T22:52:28Z",
@@ -21597,10 +21621,10 @@
    "url": "https://github.com/arimxyer/models",
    "description": "TUI for browsing AI models and coding agents",
    "category": "Development",
-   "stars": 475,
+   "stars": 479,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T16:18:07Z",
+   "pushed_at": "2026-07-26T05:47:43Z",
    "homepage": "https://reyamira.github.io/models/",
    "methods": [
     {
@@ -21637,7 +21661,7 @@
    "url": "https://github.com/dmsc/emu2",
    "description": "A simple DOS emulator for the Linux text console, supporting basic DOS system calls and console I/O.",
    "category": "Miscellaneous",
-   "stars": 461,
+   "stars": 463,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-04T04:11:57Z",
@@ -21658,10 +21682,10 @@
    "url": "https://github.com/anistark/feluda",
    "description": "Detect restrictive and incompatible licesenses in all dependencies of your project.",
    "category": "Development",
-   "stars": 457,
+   "stars": 462,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-18T08:59:34Z",
+   "pushed_at": "2026-07-25T16:25:43Z",
    "homepage": "https://feluda.readthedocs.io",
    "methods": [
     {
@@ -21698,7 +21722,7 @@
    "url": "https://github.com/Bahaaio/pomo",
    "description": "A minimal, customizable TUI Pomodoro timer with ASCII art, progress bar, desktop notifications, and productivity statistics.",
    "category": "Productivity",
-   "stars": 449,
+   "stars": 454,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-06-06T23:38:54Z",
@@ -21728,10 +21752,10 @@
    "url": "https://github.com/kriuchkov/tock",
    "description": "The powerful time tracking tool for the command line with a beautiful interactive TUI.",
    "category": "Productivity",
-   "stars": 445,
+   "stars": 446,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-15T11:14:08Z",
+   "pushed_at": "2026-07-22T01:13:33Z",
    "methods": [
     {
      "kind": "go",
@@ -21758,10 +21782,10 @@
    "url": "https://github.com/2ykwang/mac-cleanup-go",
    "description": "MacOS disk cleanup TUI: scan cache/dev artifacts, preview, exclude, and move items to Trash.",
    "category": "Miscellaneous",
-   "stars": 435,
+   "stars": 437,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-09T03:04:49Z",
+   "pushed_at": "2026-07-23T03:16:53Z",
    "methods": [
     {
      "kind": "go",
@@ -21788,10 +21812,10 @@
    "url": "https://github.com/CrociDB/bulletty",
    "description": "A pretty feed reader (ATOM/RSS) that stores articles in Markdown files",
    "category": "Web",
-   "stars": 428,
+   "stars": 431,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-06T21:34:47Z",
+   "pushed_at": "2026-07-23T13:18:28Z",
    "homepage": "http://bulletty.croci.dev/",
    "methods": [
     {
@@ -21880,7 +21904,7 @@
    "url": "https://github.com/dewberryants/asciiMol",
    "description": "Curses based ASCII molecule viewer for linux terminals.",
    "category": "Miscellaneous",
-   "stars": 414,
+   "stars": 415,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-06-24T19:07:32Z",
@@ -21952,7 +21976,7 @@
    "stars": 410,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-06-02T21:17:12Z",
+   "pushed_at": "2026-07-25T23:16:38Z",
    "methods": [
     {
      "kind": "go",
@@ -21966,6 +21990,67 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/darksworm/argonaut && cd argonaut",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "hcom",
+   "url": "https://github.com/aannoo/hcom",
+   "description": "CLI and TUI for real-time messaging, observation, and orchestration between AI coding agents (Claude Code, Antigravity, Codex, OpenCode, Kilo, Cursor) across terminals",
+   "category": "Development",
+   "stars": 403,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-26T05:05:57Z",
+   "homepage": "https://pypi.org/project/hcom/",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install hcom",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall hcom",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/aannoo/hcom && cd hcom",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "TermGL",
+   "url": "https://github.com/wojciech-graj/TermGL",
+   "description": "A terminal-based graphics library for 2D and 3D graphics.",
+   "category": "Libraries",
+   "language": "C",
+   "stars": 399,
+   "archived": false,
+   "pushed_at": "2025-12-28T22:32:17Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/wojciech-graj/TermGL && cd TermGL",
      "source": "inferred",
      "requires": [
       "git"
@@ -22005,67 +22090,6 @@
    ]
   },
   {
-   "name": "TermGL",
-   "url": "https://github.com/wojciech-graj/TermGL",
-   "description": "A terminal-based graphics library for 2D and 3D graphics.",
-   "category": "Libraries",
-   "language": "C",
-   "stars": 396,
-   "archived": false,
-   "pushed_at": "2025-12-28T22:32:17Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/wojciech-graj/TermGL && cd TermGL",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "hcom",
-   "url": "https://github.com/aannoo/hcom",
-   "description": "CLI and TUI for real-time messaging, observation, and orchestration between AI coding agents (Claude Code, Antigravity, Codex, OpenCode, Kilo, Cursor) across terminals",
-   "category": "Development",
-   "stars": 393,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-07T00:51:59Z",
-   "homepage": "https://pypi.org/project/hcom/",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install hcom",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall hcom",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/aannoo/hcom && cd hcom",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "ttop",
    "url": "https://github.com/inv2004/ttop",
    "description": "System monitoring tool with historical data service, triggers and top-like TUI",
@@ -22091,10 +22115,10 @@
    "url": "https://github.com/NSPC911/rovr",
    "description": "A post-modern terminal file manager.",
    "category": "File Managers",
-   "stars": 389,
+   "stars": 388,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-20T16:04:24Z",
+   "pushed_at": "2026-07-26T03:10:32Z",
    "homepage": "https://nspc911.github.io/rovr/",
    "methods": [
     {
@@ -22131,10 +22155,10 @@
    "url": "https://github.com/kiki-ki/go-qo",
    "description": "Interactive SQL filter for JSON, CSV, TSV and other streams.",
    "category": "Development",
-   "stars": 386,
+   "stars": 387,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-18T00:07:07Z",
+   "pushed_at": "2026-07-21T11:20:10Z",
    "methods": [
     {
      "kind": "go",
@@ -22161,10 +22185,10 @@
    "url": "https://github.com/sarub0b0/kubetui",
    "description": "A TUI tool designed for monitoring Kubernetes resources.",
    "category": "Docker/LXC/K8s",
-   "stars": 386,
+   "stars": 387,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T13:11:36Z",
+   "pushed_at": "2026-07-26T04:37:05Z",
    "methods": [
     {
      "kind": "cargo",
@@ -22200,7 +22224,7 @@
    "url": "https://github.com/NikolaDucak/caps-log",
    "description": "A small TUI journaling tool",
    "category": "Miscellaneous",
-   "stars": 385,
+   "stars": 386,
    "language": "C++",
    "archived": false,
    "pushed_at": "2026-07-13T21:58:36Z",
@@ -22222,7 +22246,7 @@
    "description": "A Flutter-like TUI framework for Dart with hot reload, 45+ components, and declarative UI patterns.",
    "category": "Libraries",
    "language": "Dart",
-   "stars": 384,
+   "stars": 385,
    "archived": false,
    "pushed_at": "2026-06-24T13:29:00Z",
    "homepage": "https://nocterm.dev",
@@ -22243,10 +22267,10 @@
    "url": "https://github.com/wcampbell0x2a/heretek",
    "description": "GDB TUI Dashboard",
    "category": "Development",
-   "stars": 383,
+   "stars": 384,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-16T17:28:45Z",
+   "pushed_at": "2026-07-21T01:13:40Z",
    "homepage": "https://wcampbell0x2a.github.io/heretek/",
    "methods": [
     {
@@ -22283,7 +22307,7 @@
    "url": "https://github.com/anmitsu/goful",
    "description": "A powerful TUI file manager written in Go.",
    "category": "File Managers",
-   "stars": 378,
+   "stars": 379,
    "language": "Go",
    "archived": false,
    "pushed_at": "2021-11-29T11:57:56Z",
@@ -22335,7 +22359,7 @@
    "url": "https://github.com/andreybleme/lazycontainer",
    "description": "TUI for managing Apple containers",
    "category": "Docker/LXC/K8s",
-   "stars": 369,
+   "stars": 370,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-02-16T22:56:41Z",
@@ -22425,7 +22449,7 @@
    "url": "https://github.com/Equationzhao/g",
    "description": "Powerful and cross-platform ls 🌈",
    "category": "CLI Tools",
-   "stars": 355,
+   "stars": 356,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-04T05:30:53Z",
@@ -22502,15 +22526,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install g",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -22519,7 +22534,7 @@
    "url": "https://github.com/felangga/chiko",
    "description": "The Ultimate Beauty TUI gRPC Client",
    "category": "Development",
-   "stars": 352,
+   "stars": 353,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-04-15T01:28:54Z",
@@ -22571,7 +22586,7 @@
    "url": "https://github.com/vitor-mariano/regex-tui",
    "description": "A simple TUI to visualize and test regular expressions",
    "category": "Development",
-   "stars": 349,
+   "stars": 350,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-04-12T01:07:22Z",
@@ -22601,10 +22616,10 @@
    "url": "https://github.com/Jaxx497/NoctaVox",
    "description": "Local TUI Music Player",
    "category": "Multimedia",
-   "stars": 346,
+   "stars": 347,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-16T06:00:02Z",
+   "pushed_at": "2026-07-23T05:39:15Z",
    "methods": [
     {
      "kind": "cargo",
@@ -22641,6 +22656,45 @@
       "brew"
      ],
      "note": "homebrew"
+    }
+   ]
+  },
+  {
+   "name": "framework-tool-tui",
+   "url": "https://github.com/grouzen/framework-tool-tui",
+   "description": "TUI for controlling and monitoring Framework Computers hardware built in Rust",
+   "category": "Dashboards",
+   "stars": 345,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-19T01:32:56Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install framework-tool-tui",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall framework-tool-tui",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/grouzen/framework-tool-tui && cd framework-tool-tui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
     }
    ]
   },
@@ -22684,80 +22738,11 @@
    ]
   },
   {
-   "name": "framework-tool-tui",
-   "url": "https://github.com/grouzen/framework-tool-tui",
-   "description": "TUI for controlling and monitoring Framework Computers hardware built in Rust",
-   "category": "Dashboards",
-   "stars": 343,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-19T01:32:56Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install framework-tool-tui",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall framework-tool-tui",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/grouzen/framework-tool-tui && cd framework-tool-tui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "gocheat",
-   "url": "https://github.com/Achno/gocheat",
-   "description": "A beautiful TUI cheatsheet for keybindings,hotkeys,gestures and aliases",
-   "category": "Productivity",
-   "stars": 341,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2025-10-26T23:18:46Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/Achno/gocheat@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/Achno/gocheat && cd gocheat",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "hygg",
    "url": "https://github.com/kruserr/hygg",
    "description": "📚 Simplifying the way you read. Minimalistic Vim-like TUI document reader.",
    "category": "Productivity",
-   "stars": 341,
+   "stars": 342,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-17T22:48:00Z",
@@ -22784,6 +22769,66 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/kruserr/hygg && cd hygg",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "gocheat",
+   "url": "https://github.com/Achno/gocheat",
+   "description": "A beautiful TUI cheatsheet for keybindings,hotkeys,gestures and aliases",
+   "category": "Productivity",
+   "stars": 340,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2025-10-26T23:18:46Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/Achno/gocheat@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/Achno/gocheat && cd gocheat",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "DockMate",
+   "url": "https://github.com/shubh-io/dockmate",
+   "description": "A lightweight TUI manager for Docker and Podman",
+   "category": "Docker/LXC/K8s",
+   "stars": 335,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-04-06T07:04:40Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/shubh-io/dockmate@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/shubh-io/dockmate && cd dockmate",
      "source": "inferred",
      "requires": [
       "git"
@@ -22833,36 +22878,6 @@
    ]
   },
   {
-   "name": "DockMate",
-   "url": "https://github.com/shubh-io/dockmate",
-   "description": "A lightweight TUI manager for Docker and Podman",
-   "category": "Docker/LXC/K8s",
-   "stars": 334,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-04-06T07:04:40Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/shubh-io/dockmate@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/shubh-io/dockmate && cd dockmate",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "lazytrivy",
    "url": "https://github.com/owenrumney/lazytrivy",
    "description": "The lazier way to scan images, k8s and the filesytem with Trivy",
@@ -22870,7 +22885,7 @@
    "stars": 326,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-10T23:26:13Z",
+   "pushed_at": "2026-07-25T03:01:35Z",
    "methods": [
     {
      "kind": "go",
@@ -22983,11 +22998,71 @@
    ]
   },
   {
+   "name": "wifitui",
+   "url": "https://github.com/shazow/wifitui",
+   "description": "Fast featureful friendly wifi terminal UI, supports NetworkManager and iwd over dbus.",
+   "category": "Miscellaneous",
+   "stars": 320,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-18T19:43:37Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/shazow/wifitui@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/shazow/wifitui && cd wifitui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "lssh",
+   "url": "https://github.com/blacknon/lssh",
+   "description": "A terminal-native remote access suite for SSH workflows, including interactive host selection, parallel commands, mux workspaces, file transfer, sync, diff, forwarding, and multi-host monitoring.",
+   "category": "Productivity",
+   "stars": 320,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-25T02:16:06Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/blacknon/lssh@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/blacknon/lssh && cd lssh",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "rura",
    "url": "https://github.com/tlipinski/rura",
    "description": "Build shell pipelines interactively, without the edit-rerun loop",
    "category": "CLI Tools",
-   "stars": 321,
+   "stars": 320,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-20T13:17:35Z",
@@ -23070,42 +23145,12 @@
    ]
   },
   {
-   "name": "lssh",
-   "url": "https://github.com/blacknon/lssh",
-   "description": "A terminal-native remote access suite for SSH workflows, including interactive host selection, parallel commands, mux workspaces, file transfer, sync, diff, forwarding, and multi-host monitoring.",
-   "category": "Productivity",
-   "stars": 319,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-10T19:26:08Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/blacknon/lssh@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/blacknon/lssh && cd lssh",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "tuibox",
    "url": "https://github.com/Cubified/tuibox",
    "description": "A single-header C terminal UI library, capable of creating mouse-driven, interactive applications on the command line.",
    "category": "Libraries",
    "language": "C",
-   "stars": 315,
+   "stars": 317,
    "archived": false,
    "pushed_at": "2023-12-01T13:21:15Z",
    "methods": [
@@ -23121,41 +23166,11 @@
    ]
   },
   {
-   "name": "wifitui",
-   "url": "https://github.com/shazow/wifitui",
-   "description": "Fast featureful friendly wifi terminal UI, supports NetworkManager and iwd over dbus.",
-   "category": "Miscellaneous",
-   "stars": 314,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-18T19:43:37Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/shazow/wifitui@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/shazow/wifitui && cd wifitui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "bastet",
    "url": "https://github.com/fph/bastet",
    "description": "Evil falling block game",
    "category": "Games",
-   "stars": 312,
+   "stars": 313,
    "language": "C++",
    "archived": false,
    "pushed_at": "2022-10-08T02:02:40Z",
@@ -23176,7 +23191,7 @@
    "url": "https://github.com/Cyxuan0311/PNANA",
    "description": "A modern terminal text editor built with FTXUI, inspired by Nano, Micro, and Sublime Text.",
    "category": "Editors",
-   "stars": 309,
+   "stars": 307,
    "language": "C++",
    "archived": false,
    "pushed_at": "2026-07-20T09:38:25Z",
@@ -23287,10 +23302,10 @@
    "url": "https://github.com/bmf-san/ggc",
    "description": "A terminal-based Git CLI tool written in Go",
    "category": "Development",
-   "stars": 284,
+   "stars": 285,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T12:44:44Z",
+   "pushed_at": "2026-07-22T11:40:21Z",
    "methods": [
     {
      "kind": "go",
@@ -23304,6 +23319,67 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/bmf-san/ggc && cd ggc",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "ec",
+   "url": "https://github.com/chojs23/ec",
+   "description": "A TUI native Git mergetool with 3 panes",
+   "category": "Development",
+   "stars": 282,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-06-11T14:01:30Z",
+   "homepage": "https://github.com/chojs23/ec",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/chojs23/ec@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/chojs23/ec && cd ec",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "pproftui",
+   "url": "https://github.com/Oloruntobi1/pproftui",
+   "description": "A terminal-based UI for Go's pprof that makes profiling interactive",
+   "category": "Development",
+   "stars": 281,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2025-07-28T22:17:35Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/Oloruntobi1/pproftui@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/Oloruntobi1/pproftui && cd pproftui",
      "source": "inferred",
      "requires": [
       "git"
@@ -23344,36 +23420,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/AfaanBilal/NanoCore && cd NanoCore",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "pproftui",
-   "url": "https://github.com/Oloruntobi1/pproftui",
-   "description": "A terminal-based UI for Go's pprof that makes profiling interactive",
-   "category": "Development",
-   "stars": 280,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2025-07-28T22:17:35Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/Oloruntobi1/pproftui@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/Oloruntobi1/pproftui && cd pproftui",
      "source": "inferred",
      "requires": [
       "git"
@@ -23426,28 +23472,64 @@
    ]
   },
   {
-   "name": "ec",
-   "url": "https://github.com/chojs23/ec",
-   "description": "A TUI native Git mergetool with 3 panes",
-   "category": "Development",
-   "stars": 277,
-   "language": "Go",
+   "name": "usbtree",
+   "url": "https://github.com/gnomeria/usbtree",
+   "description": "Live USB device tree in your terminal. Rust TUI, no root, no libusb. Full activity metrics on Linux; device tree on macOS/Windows.",
+   "category": "Dashboards",
+   "stars": 280,
+   "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-06-11T14:01:30Z",
-   "homepage": "https://github.com/chojs23/ec",
+   "pushed_at": "2026-07-25T12:53:51Z",
+   "homepage": "https://gnomeria.github.io/usbtree/",
    "methods": [
     {
-     "kind": "go",
-     "command": "go install github.com/chojs23/ec@latest",
+     "kind": "brew",
+     "command": "brew install gnomeria/tap/usbtree",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "script",
+     "command": "curl -fsSL https://raw.githubusercontent.com/gnomeria/usbtree/main/scripts/install.sh | sh",
+     "source": "readme",
+     "requires": [
+      "curl"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "cargo",
+     "command": "cargo install --git https://github.com/gnomeria/usbtree",
+     "source": "readme",
+     "requires": [
+      "cargo"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "cargo",
+     "command": "cargo install usbtree",
      "source": "inferred",
      "requires": [
-      "go"
+      "cargo"
      ],
-     "note": "module path from repo"
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall usbtree",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/chojs23/ec && cd ec",
+     "command": "git clone https://github.com/gnomeria/usbtree && cd usbtree",
      "source": "inferred",
      "requires": [
       "git"
@@ -23461,7 +23543,7 @@
    "url": "https://github.com/tassiovirginio/try-rs/",
    "description": "A lightning-fast TUI to manage temporary projects. Create, explore, and clone repositories instantly without cluttering your system.",
    "category": "Miscellaneous",
-   "stars": 277,
+   "stars": 279,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-06-15T21:41:15Z",
@@ -23488,6 +23570,69 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/tassiovirginio/try-rs && cd try-rs",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "flow",
+   "url": "https://github.com/programmersd21/flow",
+   "description": "🌊 see your network breathe",
+   "category": "Dashboards",
+   "stars": 275,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-23T13:48:32Z",
+   "methods": [
+    {
+     "kind": "yay",
+     "command": "yay -S flow-network-monitor-bin",
+     "source": "readme",
+     "requires": [
+      "yay"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "arch"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install programmersd21/flow/flow",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/programmersd21/flow/cmd/flow@latest",
+     "source": "readme",
+     "requires": [
+      "go"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/programmersd21/flow@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/programmersd21/flow && cd flow",
      "source": "inferred",
      "requires": [
       "git"
@@ -23541,7 +23686,7 @@
    "url": "https://github.com/mk-5/fjira",
    "description": "TUI application for Atlassian Jira",
    "category": "Productivity",
-   "stars": 271,
+   "stars": 272,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-07T21:41:37Z",
@@ -23656,91 +23801,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install metropolis",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
-   "name": "usbtree",
-   "url": "https://github.com/gnomeria/usbtree",
-   "description": "Live USB device tree in your terminal. Rust TUI, no root, no libusb. Full activity metrics on Linux; device tree on macOS/Windows.",
-   "category": "Dashboards",
-   "stars": 264,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-17T15:39:19Z",
-   "homepage": "https://gnomeria.github.io/usbtree/",
-   "methods": [
-    {
-     "kind": "brew",
-     "command": "brew install gnomeria/tap/usbtree",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "script",
-     "command": "curl -fsSL https://raw.githubusercontent.com/gnomeria/usbtree/main/scripts/install.sh | sh",
-     "source": "readme",
-     "requires": [
-      "curl"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "cargo",
-     "command": "cargo install --git https://github.com/gnomeria/usbtree",
-     "source": "readme",
-     "requires": [
-      "cargo"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "cargo",
-     "command": "cargo install usbtree",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall usbtree",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/gnomeria/usbtree && cd usbtree",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install usbtree",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -23749,7 +23809,7 @@
    "url": "https://github.com/rasjonell/dashbrew",
    "description": "TUI dashboard builder that lets you visualize data from scripts and APIs.",
    "category": "Dashboards",
-   "stars": 262,
+   "stars": 263,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-05-15T08:56:48Z",
@@ -23843,7 +23903,7 @@
    "url": "https://github.com/nasedkinpv/numr",
    "description": "A natural language calculator with unit/currency conversions and vim-style keybindings",
    "category": "Productivity",
-   "stars": 256,
+   "stars": 257,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-14T14:20:17Z",
@@ -23882,7 +23942,7 @@
    "url": "https://github.com/pashkov256/deletor",
    "description": "Manage and delete files efficiently with an interactive TUI and scriptable CLI.",
    "category": "File Managers",
-   "stars": 255,
+   "stars": 256,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-04-04T14:02:28Z",
@@ -23909,86 +23969,14 @@
    ]
   },
   {
-   "name": "flow",
-   "url": "https://github.com/programmersd21/flow",
-   "description": "🌊 see your network breathe",
-   "category": "Dashboards",
-   "stars": 255,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-16T03:06:32Z",
-   "methods": [
-    {
-     "kind": "yay",
-     "command": "yay -S flow-network-monitor-bin",
-     "source": "readme",
-     "requires": [
-      "yay"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "arch"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install programmersd21/flow/flow",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/programmersd21/flow/cmd/flow@latest",
-     "source": "readme",
-     "requires": [
-      "go"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/programmersd21/flow@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/programmersd21/flow && cd flow",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install flow",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
    "name": "SharpConsoleUI",
    "url": "https://github.com/nickprotop/ConsoleEx",
    "description": "Multi-window TUI framework for .NET with overlapping windows, compositor effects, and Spectre.Console integration",
    "category": "Libraries",
    "language": "C#",
-   "stars": 252,
+   "stars": 255,
    "archived": false,
-   "pushed_at": "2026-07-18T15:39:37Z",
+   "pushed_at": "2026-07-26T05:26:59Z",
    "homepage": "https://nickprotop.github.io/ConsoleEx/",
    "methods": [
     {
@@ -24007,7 +23995,7 @@
    "url": "https://github.com/GianlucaP106/mynav",
    "description": "Workspace and session management for terminal environments",
    "category": "Productivity",
-   "stars": 252,
+   "stars": 251,
    "language": "Go",
    "archived": false,
    "pushed_at": "2025-09-28T17:18:54Z",
@@ -24037,7 +24025,7 @@
    "url": "https://github.com/ryota-ka/twterm",
    "description": "A full-featured TUI Twitter client",
    "category": "Web",
-   "stars": 244,
+   "stars": 245,
    "language": "Ruby",
    "archived": false,
    "pushed_at": "2023-12-15T20:34:08Z",
@@ -24055,6 +24043,45 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/ryota-ka/twterm && cd twterm",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "SheetsUI",
+   "url": "https://github.com/zaphar/sheetsui",
+   "description": "A console based spreadsheet application",
+   "category": "Productivity",
+   "stars": 242,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-03-03T13:29:36Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install sheetsui",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall sheetsui",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/zaphar/sheetsui && cd sheetsui",
      "source": "inferred",
      "requires": [
       "git"
@@ -24090,45 +24117,6 @@
       "brew"
      ],
      "note": "homebrew"
-    }
-   ]
-  },
-  {
-   "name": "SheetsUI",
-   "url": "https://github.com/zaphar/sheetsui",
-   "description": "A console based spreadsheet application",
-   "category": "Productivity",
-   "stars": 241,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-03-03T13:29:36Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install sheetsui",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall sheetsui",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/zaphar/sheetsui && cd sheetsui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
     }
    ]
   },
@@ -24246,7 +24234,7 @@
    "url": "https://github.com/AngelJumbo/sssnake",
    "description": "The classic snake game for the terminal that can play itself and be used like a screensaver.",
    "category": "Games",
-   "stars": 233,
+   "stars": 232,
    "language": "C",
    "archived": false,
    "pushed_at": "2026-07-13T13:19:47Z",
@@ -24254,6 +24242,45 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/AngelJumbo/sssnake && cd sssnake",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "talos-pilot",
+   "url": "https://github.com/handfish/talos-pilot",
+   "description": "TUI for Talos Linux providing real-time node monitoring, log streaming, and various diagnostics",
+   "category": "Docker/LXC/K8s",
+   "stars": 230,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-24T13:57:48Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install talos-pilot",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall talos-pilot",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/handfish/talos-pilot && cd talos-pilot",
      "source": "inferred",
      "requires": [
       "git"
@@ -24305,45 +24332,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/PabloLec/neoss && cd neoss",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "talos-pilot",
-   "url": "https://github.com/handfish/talos-pilot",
-   "description": "TUI for Talos Linux providing real-time node monitoring, log streaming, and various diagnostics",
-   "category": "Docker/LXC/K8s",
-   "stars": 227,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-02-17T22:38:55Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install talos-pilot",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall talos-pilot",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/handfish/talos-pilot && cd talos-pilot",
      "source": "inferred",
      "requires": [
       "git"
@@ -24444,122 +24432,14 @@
    ]
   },
   {
-   "name": "git-crecord",
-   "url": "https://github.com/andrewshadura/git-crecord",
-   "description": "Interactive selective commit tool",
-   "category": "Development",
-   "stars": 215,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2025-05-23T12:54:43Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install git-crecord",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install git-crecord",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/andrewshadura/git-crecord && cd git-crecord",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "invidtui",
-   "url": "https://github.com/darkhz/invidtui",
-   "description": "A TUI Invidious client for Windows, Linux and MacOS, that fetches and plays audio/video from an invidious instance. Supports viewing and playing from playlists and channels as well.",
-   "category": "Multimedia",
-   "stars": 209,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2024-07-14T09:57:41Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/darkhz/invidtui@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/darkhz/invidtui && cd invidtui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "gh-enhance",
-   "url": "https://github.com/dlvhdr/gh-enhance",
-   "description": "A Blazingly Fast Terminal UI for GitHub Actions",
-   "category": "Development",
-   "stars": 208,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-15T08:52:31Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/dlvhdr/gh-enhance@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/dlvhdr/gh-enhance && cd gh-enhance",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install gh-enhance",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
    "name": "lazyskills",
    "url": "https://github.com/alvinunreal/lazyskills",
    "description": "Mission control for agent skills",
    "category": "Development",
-   "stars": 203,
+   "stars": 217,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-16T08:41:41Z",
+   "pushed_at": "2026-07-22T12:22:43Z",
    "homepage": "https://lazyskills.sh",
    "methods": [
     {
@@ -24606,15 +24486,45 @@
       "git"
      ],
      "note": "then build per the README"
-    },
+    }
+   ]
+  },
+  {
+   "name": "git-crecord",
+   "url": "https://github.com/andrewshadura/git-crecord",
+   "description": "Interactive selective commit tool",
+   "category": "Development",
+   "stars": 215,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2025-05-23T12:54:43Z",
+   "methods": [
     {
-     "kind": "brew",
-     "command": "brew install lazyskills",
+     "kind": "uv",
+     "command": "uv tool install git-crecord",
      "source": "inferred",
      "requires": [
-      "brew"
+      "uv"
      ],
-     "note": "homebrew"
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install git-crecord",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/andrewshadura/git-crecord && cd git-crecord",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
     }
    ]
   },
@@ -24623,7 +24533,7 @@
    "url": "https://github.com/marlocarlo/pstop",
    "description": "Htop-style system monitor for Windows with per-core CPU bars, tree view, and 7 color schemes.",
    "category": "Dashboards",
-   "stars": 202,
+   "stars": 211,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-18T07:57:17Z",
@@ -24650,6 +24560,75 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/marlocarlo/pstop && cd pstop",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "gh-enhance",
+   "url": "https://github.com/dlvhdr/gh-enhance",
+   "description": "A Blazingly Fast Terminal UI for GitHub Actions",
+   "category": "Development",
+   "stars": 211,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-15T08:52:31Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/dlvhdr/gh-enhance@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/dlvhdr/gh-enhance && cd gh-enhance",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install gh-enhance",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
+   "name": "invidtui",
+   "url": "https://github.com/darkhz/invidtui",
+   "description": "A TUI Invidious client for Windows, Linux and MacOS, that fetches and plays audio/video from an invidious instance. Supports viewing and playing from playlists and channels as well.",
+   "category": "Multimedia",
+   "stars": 207,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2024-07-14T09:57:41Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/darkhz/invidtui@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/darkhz/invidtui && cd invidtui",
      "source": "inferred",
      "requires": [
       "git"
@@ -24693,7 +24672,7 @@
    "url": "https://github.com/rshelekhov/lazymake",
    "description": "Modern TUI for Makefiles with interactive target selection, dependency visualization, and command safety analysis.",
    "category": "Development",
-   "stars": 198,
+   "stars": 200,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-05-11T10:40:03Z",
@@ -24725,7 +24704,7 @@
    "description": "TUI input library supporting multiple backends, tui-rs and ratatui in Rust",
    "category": "Libraries",
    "language": "Rust",
-   "stars": 197,
+   "stars": 198,
    "archived": false,
    "pushed_at": "2026-04-18T15:40:11Z",
    "methods": [
@@ -24763,7 +24742,7 @@
    "url": "https://github.com/SourcewareLab/Toney",
    "description": "A fast, lightweight, terminal-based note-taking app for the modern developer.",
    "category": "Productivity",
-   "stars": 197,
+   "stars": 198,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-05-27T06:13:16Z",
@@ -24794,7 +24773,7 @@
    "url": "https://github.com/Passeriform/BalatroTUI",
    "description": "A TUI clone of Balatro",
    "category": "Games",
-   "stars": 195,
+   "stars": 196,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-01T03:36:07Z",
@@ -24873,7 +24852,7 @@
    "url": "https://github.com/darkhz/adbtuifm",
    "description": "A TUI file manager for Android, based on the Android Debug Bridge(ADB).",
    "category": "File Managers",
-   "stars": 189,
+   "stars": 188,
    "language": "Go",
    "archived": false,
    "pushed_at": "2022-03-16T10:04:16Z",
@@ -24890,6 +24869,37 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/darkhz/adbtuifm && cd adbtuifm",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "tiki",
+   "url": "https://github.com/boolean-maybe/tiki",
+   "description": "Markdown-based git-versioned project and issue manager",
+   "category": "Productivity",
+   "stars": 188,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-22T19:53:25Z",
+   "homepage": "https://boolean-maybe.github.io/tiki/",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/boolean-maybe/tiki@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/boolean-maybe/tiki && cd tiki",
      "source": "inferred",
      "requires": [
       "git"
@@ -24945,7 +24955,7 @@
    "stars": 186,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-15T04:14:01Z",
+   "pushed_at": "2026-07-22T04:15:19Z",
    "homepage": "https://crates.io/crates/cargo-seek",
    "methods": [
     {
@@ -24969,37 +24979,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/tareqimbasher/cargo-seek && cd cargo-seek",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "tiki",
-   "url": "https://github.com/boolean-maybe/tiki",
-   "description": "Markdown-based git-versioned project and issue manager",
-   "category": "Productivity",
-   "stars": 186,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-17T13:36:04Z",
-   "homepage": "https://boolean-maybe.github.io/tiki/",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/boolean-maybe/tiki@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/boolean-maybe/tiki && cd tiki",
      "source": "inferred",
      "requires": [
       "git"
@@ -25065,7 +25044,7 @@
    "url": "https://github.com/cruise-org/cruise",
    "description": "A container management TUI",
    "category": "Docker/LXC/K8s",
-   "stars": 180,
+   "stars": 181,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-09T08:06:49Z",
@@ -25096,7 +25075,7 @@
    "url": "https://github.com/mentebinaria/dz6",
    "description": "Fast Vim-inspired hex editor for the terminal",
    "category": "Miscellaneous",
-   "stars": 180,
+   "stars": 181,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-18T19:22:32Z",
@@ -25141,18 +25120,19 @@
    ]
   },
   {
-   "name": "UniCurses",
-   "url": "https://github.com/unicurses/unicurses",
-   "description": "A Python module that is aimed at providing the Curses functionality on all operating systems.",
-   "category": "Libraries",
-   "language": "Python",
+   "name": "Twig",
+   "url": "https://github.com/workdone0/twig",
+   "description": "Terminal UI for interactively exploring JSON and YAML files.",
+   "category": "Development",
    "stars": 172,
+   "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-09T18:28:12Z",
+   "pushed_at": "2026-05-22T09:45:37Z",
+   "homepage": "https://twig.wtf/",
    "methods": [
     {
      "kind": "uv",
-     "command": "uv tool install unicurses",
+     "command": "uv tool install twig",
      "source": "inferred",
      "requires": [
       "uv"
@@ -25161,7 +25141,7 @@
     },
     {
      "kind": "pipx",
-     "command": "pipx install unicurses",
+     "command": "pipx install twig",
      "source": "inferred",
      "requires": [
       "pipx"
@@ -25170,7 +25150,7 @@
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/unicurses/unicurses && cd unicurses",
+     "command": "git clone https://github.com/workdone0/twig && cd twig",
      "source": "inferred",
      "requires": [
       "git"
@@ -25219,51 +25199,11 @@
    ]
   },
   {
-   "name": "Twig",
-   "url": "https://github.com/workdone0/twig",
-   "description": "Terminal UI for interactively exploring JSON and YAML files.",
-   "category": "Development",
-   "stars": 171,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2026-05-22T09:45:37Z",
-   "homepage": "https://twig.wtf/",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install twig",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install twig",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/workdone0/twig && cd twig",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "Micro Tetris",
    "url": "https://github.com/troglobit/tetris",
    "description": "One of the smallest Tetris implementations in the world, utilizing only ANSI escape sequences to draw the board.",
    "category": "Games",
-   "stars": 170,
+   "stars": 171,
    "language": "C",
    "archived": false,
    "pushed_at": "2025-06-22T15:42:04Z",
@@ -25281,12 +25221,51 @@
    ]
   },
   {
+   "name": "UniCurses",
+   "url": "https://github.com/unicurses/unicurses",
+   "description": "A Python module that is aimed at providing the Curses functionality on all operating systems.",
+   "category": "Libraries",
+   "language": "Python",
+   "stars": 171,
+   "archived": false,
+   "pushed_at": "2026-07-09T18:28:12Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install unicurses",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install unicurses",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/unicurses/unicurses && cd unicurses",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "Hex1b",
    "url": "https://github.com/mitchdenny/hex1b",
    "description": "A .NET library for building rich, interactive TUIs with a React-inspired declarative API",
    "category": "Libraries",
    "language": "C#",
-   "stars": 169,
+   "stars": 170,
    "archived": false,
    "pushed_at": "2026-06-25T10:11:54Z",
    "homepage": "https://hex1b.dev",
@@ -25294,6 +25273,27 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/mitchdenny/hex1b && cd hex1b",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "podliner",
+   "url": "https://github.com/timkicker/podliner",
+   "description": "A cross-platform podcast client",
+   "category": "Web",
+   "stars": 170,
+   "language": "C#",
+   "archived": false,
+   "pushed_at": "2026-04-25T17:40:46Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/timkicker/podliner && cd podliner",
      "source": "inferred",
      "requires": [
       "git"
@@ -25372,27 +25372,6 @@
    ]
   },
   {
-   "name": "podliner",
-   "url": "https://github.com/timkicker/podliner",
-   "description": "A cross-platform podcast client",
-   "category": "Web",
-   "stars": 168,
-   "language": "C#",
-   "archived": false,
-   "pushed_at": "2026-04-25T17:40:46Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/timkicker/podliner && cd podliner",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "Canard",
    "url": "https://github.com/mrusme/canard",
    "description": "A command line TUI client for the Journalist RSS aggregator.",
@@ -25428,7 +25407,7 @@
    "url": "https://github.com/sugyan/tuisky",
    "description": "TUI client for BlueSky",
    "category": "Messaging",
-   "stars": 164,
+   "stars": 165,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2025-12-28T03:05:34Z",
@@ -25493,80 +25472,11 @@
    ]
   },
   {
-   "name": "waves",
-   "url": "https://github.com/llehouerou/waves",
-   "description": "Terminal music player with vim-style navigation and radio mode that plays similar artists from your library",
-   "category": "Multimedia",
-   "stars": 160,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-06-18T18:16:05Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/llehouerou/waves@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/llehouerou/waves && cd waves",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "tray-tui",
-   "url": "https://github.com/Levizor/tray-tui",
-   "description": "System tray in your terminal",
-   "category": "Miscellaneous",
-   "stars": 159,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-03-15T13:53:57Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install tray-tui",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall tray-tui",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/Levizor/tray-tui && cd tray-tui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "riptide",
    "url": "https://github.com/Foxemsx/riptide",
    "description": "A polished terminal internet speed test and realtime bandwidth monitor written in Go. Riptide measures download, upload, and latency in a centered card UI with live progress, compact sparklines, smooth animation, and clean cross-platform output for Linux and Windows terminals.",
    "category": "Dashboards",
-   "stars": 159,
+   "stars": 162,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-13T13:09:20Z",
@@ -25628,6 +25538,132 @@
    ]
   },
   {
+   "name": "tray-tui",
+   "url": "https://github.com/Levizor/tray-tui",
+   "description": "System tray in your terminal",
+   "category": "Miscellaneous",
+   "stars": 161,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-03-15T13:53:57Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install tray-tui",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall tray-tui",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/Levizor/tray-tui && cd tray-tui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "waves",
+   "url": "https://github.com/llehouerou/waves",
+   "description": "Terminal music player with vim-style navigation and radio mode that plays similar artists from your library",
+   "category": "Multimedia",
+   "stars": 160,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-06-18T18:16:05Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/llehouerou/waves@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/llehouerou/waves && cd waves",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "stocksTUI",
+   "url": "https://github.com/andriy-git/stocksTUI",
+   "description": "StocksTUI: Real-time stock market data in your terminal.",
+   "category": "Dashboards",
+   "stars": 156,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2026-07-09T01:05:25Z",
+   "methods": [
+    {
+     "kind": "pipx",
+     "command": "pipx install stocksTUI",
+     "source": "readme",
+     "requires": [
+      "pipx"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "uv",
+     "command": "uv tool install stockstui",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install stockstui",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/andriy-git/stocksTUI && cd stocksTUI",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install stockstui",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
    "name": "mpvc",
    "url": "https://github.com/gmt4/mpvc",
    "description": "A mpc-like control interface for mpv",
@@ -25635,7 +25671,7 @@
    "stars": 153,
    "language": "Shell",
    "archived": false,
-   "pushed_at": "2026-07-20T06:07:39Z",
+   "pushed_at": "2026-07-25T14:48:22Z",
    "homepage": "https://gmt4.github.io/mpvc/",
    "methods": [
     {
@@ -25689,6 +25725,67 @@
    ]
   },
   {
+   "name": "kanban",
+   "url": "https://github.com/fulsomenko/kanban",
+   "description": "TUI kanban board for projects management with sprint tracking and task prioritization.",
+   "category": "Productivity",
+   "stars": 150,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-25T23:10:44Z",
+   "homepage": "https://kanban.rs",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install kanban",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall kanban",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/fulsomenko/kanban && cd kanban",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "line",
+   "url": "https://github.com/pd3v/line",
+   "description": "Tiny command-line midi sequencer and language for live coding",
+   "category": "Multimedia",
+   "stars": 149,
+   "language": "C++",
+   "archived": false,
+   "pushed_at": "2025-08-11T17:25:49Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/pd3v/line && cd line",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "redu",
    "url": "https://github.com/drdo/redu",
    "description": "Ncdu for your restic repository that manages exclusion lists to prune files from existing repos and skip new ones",
@@ -25720,46 +25817,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/drdo/redu && cd redu",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "kanban",
-   "url": "https://github.com/fulsomenko/kanban",
-   "description": "TUI kanban board for projects management with sprint tracking and task prioritization.",
-   "category": "Productivity",
-   "stars": 148,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T12:54:00Z",
-   "homepage": "https://kanban.rs",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install kanban",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall kanban",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/fulsomenko/kanban && cd kanban",
      "source": "inferred",
      "requires": [
       "git"
@@ -25846,7 +25903,7 @@
    "stars": 145,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-06-28T03:56:20Z",
+   "pushed_at": "2026-07-25T16:29:51Z",
    "methods": [
     {
      "kind": "go",
@@ -25869,32 +25926,11 @@
    ]
   },
   {
-   "name": "opcilloscope",
-   "url": "https://github.com/SquareWaveSystems/opcilloscope",
-   "description": "OPC UA client TUI with real-time oscilloscope view for industrial automation",
-   "category": "Development",
-   "stars": 143,
-   "language": "C#",
-   "archived": false,
-   "pushed_at": "2026-07-16T09:25:08Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/SquareWaveSystems/opcilloscope && cd opcilloscope",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "terminalperiodictable",
    "url": "https://github.com/velorek1/terminalperiodictable",
    "description": "A beautiful TUI periodic table for Unix systems coded in C.",
    "category": "Miscellaneous",
-   "stars": 143,
+   "stars": 144,
    "language": "C",
    "archived": false,
    "pushed_at": "2025-08-01T19:13:39Z",
@@ -25911,95 +25947,14 @@
    ]
   },
   {
-   "name": "line",
-   "url": "https://github.com/pd3v/line",
-   "description": "Tiny command-line midi sequencer and language for live coding",
-   "category": "Multimedia",
-   "stars": 143,
-   "language": "C++",
-   "archived": false,
-   "pushed_at": "2025-08-11T17:25:49Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/pd3v/line && cd line",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "helm",
-   "url": "https://github.com/0xjuanma/helm",
-   "description": "A minimalistic & customizable pomodoro-like timer for your terminal",
-   "category": "Productivity",
-   "stars": 142,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-01-23T03:46:55Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/0xjuanma/helm@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/0xjuanma/helm && cd helm",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "amux",
-   "url": "https://github.com/andyrewlee/amux",
-   "description": "Easily run parallel coding agents",
-   "category": "Development",
-   "stars": 140,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-18T21:28:32Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/andyrewlee/amux@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/andyrewlee/amux && cd amux",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "wlctl",
    "url": "https://github.com/aashish-thapa/wlctl",
    "description": "🛜 TUI for managing wifi/ethernet/vpn on Linux with Network Manager",
    "category": "CLI Tools",
-   "stars": 139,
+   "stars": 144,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-19T02:17:49Z",
+   "pushed_at": "2026-07-24T18:00:35Z",
    "methods": [
     {
      "kind": "cargo",
@@ -26055,6 +26010,117 @@
    ]
   },
   {
+   "name": "amux",
+   "url": "https://github.com/andyrewlee/amux",
+   "description": "Easily run parallel coding agents",
+   "category": "Development",
+   "stars": 143,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-26T04:39:18Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/andyrewlee/amux@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/andyrewlee/amux && cd amux",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "opcilloscope",
+   "url": "https://github.com/SquareWaveSystems/opcilloscope",
+   "description": "OPC UA client TUI with real-time oscilloscope view for industrial automation",
+   "category": "Development",
+   "stars": 143,
+   "language": "C#",
+   "archived": false,
+   "pushed_at": "2026-07-16T09:25:08Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/SquareWaveSystems/opcilloscope && cd opcilloscope",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "helm",
+   "url": "https://github.com/0xjuanma/helm",
+   "description": "A minimalistic & customizable pomodoro-like timer for your terminal",
+   "category": "Productivity",
+   "stars": 143,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-26T02:17:48Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/0xjuanma/helm@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/0xjuanma/helm && cd helm",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "CrunchyCleaner",
+   "url": "https://github.com/knuspii/crunchycleaner",
+   "description": "A lightweight, software cache cleanup tool for Windows & Linux.",
+   "category": "Miscellaneous",
+   "stars": 136,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-22T19:09:17Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/knuspii/crunchycleaner@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/knuspii/crunchycleaner && cd crunchycleaner",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "ssh-slides",
    "url": "https://github.com/ivantsepp/ssh-slides",
    "description": "Terminal-based presentations over SSH",
@@ -26086,183 +26152,14 @@
    ]
   },
   {
-   "name": "Maze",
-   "url": "https://github.com/itchyny/maze",
-   "description": "Simple maze game written in Go.",
-   "category": "Games",
-   "stars": 128,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2024-03-23T02:15:13Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/itchyny/maze@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/itchyny/maze && cd maze",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "psnet",
-   "url": "https://github.com/marlocarlo/psnet",
-   "description": "Real-time TUI network monitor for Windows with speed graphs, DNS resolution, and packet inspection.",
-   "category": "Dashboards",
-   "stars": 124,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-18T07:57:18Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install psnet",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall psnet",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/marlocarlo/psnet && cd psnet",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "CrunchyCleaner",
-   "url": "https://github.com/knuspii/crunchycleaner",
-   "description": "A lightweight, software cache cleanup tool for Windows & Linux.",
-   "category": "Miscellaneous",
-   "stars": 124,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-17T06:54:06Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/knuspii/crunchycleaner@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/knuspii/crunchycleaner && cd crunchycleaner",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "awsui",
-   "url": "https://github.com/junminhong/awsui",
-   "description": "A powerful, user-friendly terminal interface for AWS Profile and SSO management.",
-   "category": "Productivity",
-   "stars": 123,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2025-10-14T01:19:00Z",
-   "homepage": "https://junminhong.github.io/awsui/",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install awsui",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install awsui",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/junminhong/awsui && cd awsui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "htui",
-   "url": "https://github.com/PierreKieffer/htui",
-   "description": "Heroku Terminal User Interface",
-   "category": "Dashboards",
-   "stars": 122,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2021-04-26T12:03:44Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/PierreKieffer/htui@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/PierreKieffer/htui && cd htui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "ttt",
    "url": "https://github.com/eugenioenko/ttt",
    "description": "TTT Editor - Terminal Text Tool: a terminal text editor IDE. A real alternative to VS Code, Zed, and Sublime that runs in your terminal. Single binary, zero config.",
    "category": "Editors",
-   "stars": 122,
+   "stars": 134,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T04:39:05Z",
+   "pushed_at": "2026-07-23T21:53:38Z",
    "homepage": "http://tttedit.dev/",
    "methods": [
     {
@@ -26337,11 +26234,268 @@
    ]
   },
   {
+   "name": "psnet",
+   "url": "https://github.com/marlocarlo/psnet",
+   "description": "Real-time TUI network monitor for Windows with speed graphs, DNS resolution, and packet inspection.",
+   "category": "Dashboards",
+   "stars": 133,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-18T07:57:18Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install psnet",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall psnet",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/marlocarlo/psnet && cd psnet",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "fast-resume",
+   "url": "https://github.com/angristan/fast-resume",
+   "description": "Index and fuzzy search coding agent sessions",
+   "category": "Development",
+   "stars": 133,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-24T07:34:15Z",
+   "homepage": "https://stanislas.blog/2026/01/tui-index-search-coding-agent-sessions/",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install fast-resume",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall fast-resume",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/angristan/fast-resume && cd fast-resume",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "Maze",
+   "url": "https://github.com/itchyny/maze",
+   "description": "Simple maze game written in Go.",
+   "category": "Games",
+   "stars": 128,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2024-03-23T02:15:13Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/itchyny/maze@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/itchyny/maze && cd maze",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "htui",
+   "url": "https://github.com/PierreKieffer/htui",
+   "description": "Heroku Terminal User Interface",
+   "category": "Dashboards",
+   "stars": 123,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2021-04-26T12:03:44Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/PierreKieffer/htui@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/PierreKieffer/htui && cd htui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "awsui",
+   "url": "https://github.com/junminhong/awsui",
+   "description": "A powerful, user-friendly terminal interface for AWS Profile and SSO management.",
+   "category": "Productivity",
+   "stars": 123,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2025-10-14T01:19:00Z",
+   "homepage": "https://junminhong.github.io/awsui/",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install awsui",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install awsui",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/junminhong/awsui && cd awsui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "ditto",
+   "url": "https://github.com/arvingarciabtw/ditto",
+   "description": "A system-wide ascii keyboard visualizer and keycaster in the terminal",
+   "category": "Multimedia",
+   "stars": 121,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-26T02:39:40Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/arvingarciabtw/ditto/cmd/ditto@latest",
+     "source": "readme",
+     "requires": [
+      "go"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "yay",
+     "command": "yay -S ditto",
+     "source": "readme",
+     "requires": [
+      "yay"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "arch"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "paru",
+     "command": "paru -S ditto",
+     "source": "readme",
+     "requires": [
+      "paru"
+     ],
+     "os": [
+      "linux"
+     ],
+     "families": [
+      "arch"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "go",
+     "command": "go install github.com/arvingarciabtw/ditto@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/arvingarciabtw/ditto && cd ditto",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install ditto",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
    "name": "AetherTune",
    "url": "https://github.com/nevermore23274/AetherTune",
    "description": "A terminal-based internet radio player with real-time audio visualization, built in Rust.",
    "category": "Multimedia",
-   "stars": 121,
+   "stars": 120,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-05-28T22:08:29Z",
@@ -26439,46 +26593,6 @@
    ]
   },
   {
-   "name": "fast-resume",
-   "url": "https://github.com/angristan/fast-resume",
-   "description": "Index and fuzzy search coding agent sessions",
-   "category": "Development",
-   "stars": 119,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-18T21:05:58Z",
-   "homepage": "https://stanislas.blog/2026/01/tui-index-search-coding-agent-sessions/",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install fast-resume",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall fast-resume",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/angristan/fast-resume && cd fast-resume",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "Ashen",
    "url": "https://github.com/colinta/Ashen",
    "description": "An Elm inspired framework written in Swift",
@@ -26500,150 +26614,11 @@
    ]
   },
   {
-   "name": "ditto",
-   "url": "https://github.com/arvingarciabtw/ditto",
-   "description": "A system-wide ascii keyboard visualizer in the terminal",
-   "category": "Multimedia",
-   "stars": 117,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-16T04:50:39Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/arvingarciabtw/ditto/cmd/ditto@latest",
-     "source": "readme",
-     "requires": [
-      "go"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "yay",
-     "command": "yay -S ditto",
-     "source": "readme",
-     "requires": [
-      "yay"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "arch"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "paru",
-     "command": "paru -S ditto",
-     "source": "readme",
-     "requires": [
-      "paru"
-     ],
-     "os": [
-      "linux"
-     ],
-     "families": [
-      "arch"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "go",
-     "command": "go install github.com/arvingarciabtw/ditto@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/arvingarciabtw/ditto && cd ditto",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install ditto",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
-    }
-   ]
-  },
-  {
-   "name": "Judo",
-   "url": "https://github.com/giacomopiccinini/judo",
-   "description": "A multi-database TUI for ToDo lists, using Rust + Ratatui + SQLite",
-   "category": "Productivity",
-   "stars": 115,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-02-16T19:58:45Z",
-   "homepage": "https://crates.io/crates/judo",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install judo",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall judo",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/giacomopiccinini/judo && cd judo",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "snake",
-   "url": "https://github.com/wick3dr0se/snake",
-   "description": ":videogame: A super minimal TUI snake game written in pure BASH v5.1+",
-   "category": "Games",
-   "stars": 114,
-   "language": "Shell",
-   "archived": false,
-   "pushed_at": "2023-06-17T22:38:55Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/wick3dr0se/snake && cd snake",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "tttui",
    "url": "https://github.com/reidoboss/tttui",
    "description": "A Monkeytype-inspired typing test that runs entirely in your terminal",
    "category": "Miscellaneous",
-   "stars": 114,
+   "stars": 116,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-18T05:17:23Z",
@@ -26679,14 +26654,54 @@
    ]
   },
   {
+   "name": "Judo",
+   "url": "https://github.com/giacomopiccinini/judo",
+   "description": "A multi-database TUI for ToDo lists, using Rust + Ratatui + SQLite",
+   "category": "Productivity",
+   "stars": 116,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-02-16T19:58:45Z",
+   "homepage": "https://crates.io/crates/judo",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install judo",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall judo",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/giacomopiccinini/judo && cd judo",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "gitv",
    "url": "https://github.com/jayanaxhf/gitv",
    "description": ": A beautiful, feature-rich and performant terminal client for GitHub issues.",
    "category": "Development",
-   "stars": 113,
+   "stars": 114,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-16T14:35:08Z",
+   "pushed_at": "2026-07-23T14:34:47Z",
    "homepage": "https://crates.io/crates/gitv-tui",
    "methods": [
     {
@@ -26710,6 +26725,58 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/jayanaxhf/gitv && cd gitv",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "snake",
+   "url": "https://github.com/wick3dr0se/snake",
+   "description": ":videogame: A super minimal TUI snake game written in pure BASH v5.1+",
+   "category": "Games",
+   "stars": 114,
+   "language": "Shell",
+   "archived": false,
+   "pushed_at": "2023-06-17T22:38:55Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/wick3dr0se/snake && cd snake",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "d4s",
+   "url": "https://github.com/jr-k/d4s",
+   "description": "A fast, keyboard-driven terminal UI to manage Docker containers, Compose stacks, and Swarm services with the ergonomics of K9s",
+   "category": "Docker/LXC/K8s",
+   "stars": 113,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-22T11:52:30Z",
+   "homepage": "https://d4scli.io",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/jr-k/d4s@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/jr-k/d4s && cd d4s",
      "source": "inferred",
      "requires": [
       "git"
@@ -26759,6 +26826,45 @@
    ]
   },
   {
+   "name": "Quorum",
+   "url": "https://github.com/Detrol/quorum-cli",
+   "description": "Multi-agent AI discussion system for structured debates between LLMs",
+   "category": "Development",
+   "stars": 112,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2026-01-01T20:26:00Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install quorum-cli",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install quorum-cli",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/Detrol/quorum-cli && cd quorum-cli",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "pyautogit",
    "url": "https://github.com/jwlodek/pyautogit",
    "description": "A terminal UI for managing git repositories, written using pycui",
@@ -26799,50 +26905,11 @@
    ]
   },
   {
-   "name": "Quorum",
-   "url": "https://github.com/Detrol/quorum-cli",
-   "description": "Multi-agent AI discussion system for structured debates between LLMs",
-   "category": "Development",
-   "stars": 111,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2026-01-01T20:26:00Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install quorum-cli",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install quorum-cli",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/Detrol/quorum-cli && cd quorum-cli",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "csol",
    "url": "https://github.com/nielssp/csol",
    "description": "Collection of solitaire/patience games, such as Klondike, FreeCell, Spider, and Yukon",
    "category": "Games",
-   "stars": 111,
+   "stars": 112,
    "language": "C",
    "archived": false,
    "pushed_at": "2025-07-19T11:35:04Z",
@@ -26860,36 +26927,46 @@
    ]
   },
   {
-   "name": "procmux",
-   "url": "https://github.com/napisani/procmux",
-   "description": "A TUI for running multiple commands in parallel in easily switchable terminals",
-   "category": "Productivity",
-   "stars": 111,
-   "language": "Python",
+   "name": "noodle",
+   "url": "https://github.com/wilfredinni/noodle",
+   "description": "A delicious REST client for your terminal",
+   "category": "CLI Tools",
+   "stars": 112,
+   "language": "TypeScript",
    "archived": false,
-   "pushed_at": "2025-11-23T15:52:24Z",
+   "pushed_at": "2026-07-26T03:32:01Z",
+   "homepage": "https://noodlerest.dev",
    "methods": [
     {
-     "kind": "uv",
-     "command": "uv tool install procmux",
-     "source": "inferred",
+     "kind": "script",
+     "command": "curl -LsSf https://noodlerest.dev/install.sh | sh",
+     "source": "readme",
      "requires": [
-      "uv"
+      "curl"
      ],
-     "note": "guessed from repo name"
+     "note": "from README"
     },
     {
-     "kind": "pipx",
-     "command": "pipx install procmux",
+     "kind": "brew",
+     "command": "brew install noodle",
+     "source": "readme",
+     "requires": [
+      "brew"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "npm",
+     "command": "npm install -g noodle",
      "source": "inferred",
      "requires": [
-      "pipx"
+      "npm"
      ],
      "note": "guessed from repo name"
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/napisani/procmux && cd procmux",
+     "command": "git clone https://github.com/wilfredinni/noodle && cd noodle",
      "source": "inferred",
      "requires": [
       "git"
@@ -26899,19 +26976,18 @@
    ]
   },
   {
-   "name": "d4s",
-   "url": "https://github.com/jr-k/d4s",
-   "description": "A fast, keyboard-driven terminal UI to manage Docker containers, Compose stacks, and Swarm services with the ergonomics of K9s",
-   "category": "Docker/LXC/K8s",
-   "stars": 110,
+   "name": "amtui",
+   "url": "https://github.com/pehlicd/amtui/",
+   "description": "Alertmanager TUI - Your Terminal Companion for Alertmanager",
+   "category": "Development",
+   "stars": 111,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-15T12:42:15Z",
-   "homepage": "https://d4scli.io",
+   "pushed_at": "2026-06-20T07:53:47Z",
    "methods": [
     {
      "kind": "go",
-     "command": "go install github.com/jr-k/d4s@latest",
+     "command": "go install github.com/pehlicd/amtui@latest",
      "source": "inferred",
      "requires": [
       "go"
@@ -26920,7 +26996,7 @@
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/jr-k/d4s && cd d4s",
+     "command": "git clone https://github.com/pehlicd/amtui && cd amtui",
      "source": "inferred",
      "requires": [
       "git"
@@ -26935,7 +27011,7 @@
    "description": "A Java terminal UI framework with a Bubble Tea (Go) port and additional features inspired by Textual.",
    "category": "Libraries",
    "language": "Java",
-   "stars": 110,
+   "stars": 111,
    "archived": false,
    "pushed_at": "2026-04-02T19:05:22Z",
    "homepage": "https://williamcallahan.com/projects/tui4j",
@@ -26982,27 +27058,36 @@
    ]
   },
   {
-   "name": "amtui",
-   "url": "https://github.com/pehlicd/amtui/",
-   "description": "Alertmanager TUI - Your Terminal Companion for Alertmanager",
-   "category": "Development",
-   "stars": 109,
-   "language": "Go",
+   "name": "procmux",
+   "url": "https://github.com/napisani/procmux",
+   "description": "A TUI for running multiple commands in parallel in easily switchable terminals",
+   "category": "Productivity",
+   "stars": 110,
+   "language": "Python",
    "archived": false,
-   "pushed_at": "2026-06-20T07:53:47Z",
+   "pushed_at": "2025-11-23T15:52:24Z",
    "methods": [
     {
-     "kind": "go",
-     "command": "go install github.com/pehlicd/amtui@latest",
+     "kind": "uv",
+     "command": "uv tool install procmux",
      "source": "inferred",
      "requires": [
-      "go"
+      "uv"
      ],
-     "note": "module path from repo"
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install procmux",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/pehlicd/amtui && cd amtui",
+     "command": "git clone https://github.com/napisani/procmux && cd procmux",
      "source": "inferred",
      "requires": [
       "git"
@@ -27019,7 +27104,7 @@
    "stars": 109,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-06-09T12:26:57Z",
+   "pushed_at": "2026-07-20T19:41:59Z",
    "homepage": "https://datadoghq.dev/ddqa/",
    "methods": [
     {
@@ -27043,6 +27128,37 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/DataDog/ddqa && cd ddqa",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "git-scope",
+   "url": "https://github.com/Bharath-code/git-scope",
+   "description": "Terminal UI dashboard for inspecting multiple local Git repositories.",
+   "category": "Development",
+   "stars": 109,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-06-14T07:47:47Z",
+   "homepage": "https://bharath-code.github.io/git-scope/",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/Bharath-code/git-scope@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/Bharath-code/git-scope && cd git-scope",
      "source": "inferred",
      "requires": [
       "git"
@@ -27096,37 +27212,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/mrusme/gomphotherium && cd gomphotherium",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "git-scope",
-   "url": "https://github.com/Bharath-code/git-scope",
-   "description": "Terminal UI dashboard for inspecting multiple local Git repositories.",
-   "category": "Development",
-   "stars": 107,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-06-14T07:47:47Z",
-   "homepage": "https://bharath-code.github.io/git-scope/",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/Bharath-code/git-scope@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/Bharath-code/git-scope && cd git-scope",
      "source": "inferred",
      "requires": [
       "git"
@@ -27227,6 +27312,27 @@
    ]
   },
   {
+   "name": "ConsoleCraftEngine",
+   "url": "https://github.com/ural89/ConsoleCraftEngine",
+   "description": "A terminal-based 2D game engine written in C++.",
+   "category": "Libraries",
+   "language": "C++",
+   "stars": 95,
+   "archived": false,
+   "pushed_at": "2026-02-15T06:18:06Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/ural89/ConsoleCraftEngine && cd ConsoleCraftEngine",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "Thermage",
    "url": "https://github.com/thermage/thermage",
    "description": "Thermage is a PHP library that provides a fluent and incredibly powerful, object-oriented interface for customizing CLI output text color, background, formatting, theming and more.",
@@ -27249,35 +27355,14 @@
    ]
   },
   {
-   "name": "ConsoleCraftEngine",
-   "url": "https://github.com/ural89/ConsoleCraftEngine",
-   "description": "A terminal-based 2D game engine written in C++.",
-   "category": "Libraries",
-   "language": "C++",
-   "stars": 94,
-   "archived": false,
-   "pushed_at": "2026-02-15T06:18:06Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/ural89/ConsoleCraftEngine && cd ConsoleCraftEngine",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "suvadu",
    "url": "https://github.com/AppachiTech/suvadu",
    "description": "Shell history replacement with AI agent tracking and MCP server. Built in Rust, 100% local.",
    "category": "Shell & Prompt",
-   "stars": 93,
+   "stars": 94,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-06-25T14:00:22Z",
+   "pushed_at": "2026-07-22T14:46:00Z",
    "homepage": "https://suvadu.sh",
    "methods": [
     {
@@ -27324,15 +27409,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install suvadu",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -27420,51 +27496,11 @@
    ]
   },
   {
-   "name": "portfolio_rs",
-   "url": "https://github.com/MarkusZoppelt/portfolio_rs",
-   "description": "A command line tool for managing financial investment portfolios.",
-   "category": "Productivity",
-   "stars": 90,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-07-20T11:52:24Z",
-   "homepage": "https://crates.io/crates/portfolio_rs",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install portfolio_rs",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall portfolio_rs",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/MarkusZoppelt/portfolio_rs && cd portfolio_rs",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "rusty-pipes",
    "url": "https://github.com/dividebysandwich/rusty-pipes",
    "description": "A sample-based, MIDI-controlled virtual pipe organ instrument compatible with GrandOrgue and Hauptwerk sample sets.",
    "category": "Multimedia",
-   "stars": 89,
+   "stars": 90,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-06-22T07:03:27Z",
@@ -27491,6 +27527,46 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/dividebysandwich/rusty-pipes && cd rusty-pipes",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "portfolio_rs",
+   "url": "https://github.com/MarkusZoppelt/portfolio_rs",
+   "description": "A command line tool for managing financial investment portfolios.",
+   "category": "Productivity",
+   "stars": 90,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-23T09:17:28Z",
+   "homepage": "https://crates.io/crates/portfolio_rs",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install portfolio_rs",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall portfolio_rs",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/MarkusZoppelt/portfolio_rs && cd portfolio_rs",
      "source": "inferred",
      "requires": [
       "git"
@@ -27610,37 +27686,6 @@
    ]
   },
   {
-   "name": "openmux",
-   "url": "https://github.com/monotykamary/openmux",
-   "description": "A terminal multiplexer with master-stack layout (Zellij-style)",
-   "category": "Productivity",
-   "stars": 85,
-   "language": "TypeScript",
-   "archived": false,
-   "pushed_at": "2026-06-16T06:54:15Z",
-   "homepage": "https://www.npmjs.com/package/openmux",
-   "methods": [
-    {
-     "kind": "npm",
-     "command": "npm install -g openmux",
-     "source": "inferred",
-     "requires": [
-      "npm"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/monotykamary/openmux && cd openmux",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "HumBLE Explorer",
    "url": "https://github.com/koenvervloesem/humble-explorer",
    "description": "A cross-platform, command-line and human-friendly Bluetooth Low Energy scanner",
@@ -27681,6 +27726,36 @@
    ]
   },
   {
+   "name": "Gorae",
+   "url": "https://github.com/Han8931/gorae",
+   "description": "TUI librarian for PDFs and EPUBs with Vim-style navigation.",
+   "category": "Multimedia",
+   "stars": 84,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-26T03:38:33Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/Han8931/gorae@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/Han8931/gorae && cd gorae",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "sonicradio",
    "url": "https://github.com/dancnb/sonicradio",
    "description": "A stylish TUI radio player making use of Radio Browser API and Bubbletea.",
@@ -27711,37 +27786,19 @@
    ]
   },
   {
-   "name": "noodle",
-   "url": "https://github.com/wilfredinni/noodle",
-   "description": "A delicious REST client for your terminal",
-   "category": "CLI Tools",
+   "name": "openmux",
+   "url": "https://github.com/monotykamary/openmux",
+   "description": "A terminal multiplexer with master-stack layout (Zellij-style)",
+   "category": "Productivity",
    "stars": 84,
    "language": "TypeScript",
    "archived": false,
-   "pushed_at": "2026-07-19T16:37:15Z",
-   "homepage": "https://noodlerest.dev",
+   "pushed_at": "2026-06-16T06:54:15Z",
+   "homepage": "https://www.npmjs.com/package/openmux",
    "methods": [
     {
-     "kind": "script",
-     "command": "curl -LsSf https://noodlerest.dev/install.sh | sh",
-     "source": "readme",
-     "requires": [
-      "curl"
-     ],
-     "note": "from README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install noodle",
-     "source": "readme",
-     "requires": [
-      "brew"
-     ],
-     "note": "from README"
-    },
-    {
      "kind": "npm",
-     "command": "npm install -g noodle",
+     "command": "npm install -g openmux",
      "source": "inferred",
      "requires": [
       "npm"
@@ -27750,7 +27807,7 @@
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/wilfredinni/noodle && cd noodle",
+     "command": "git clone https://github.com/monotykamary/openmux && cd openmux",
      "source": "inferred",
      "requires": [
       "git"
@@ -27869,36 +27926,6 @@
    ]
   },
   {
-   "name": "Gorae",
-   "url": "https://github.com/Han8931/gorae",
-   "description": "TUI librarian for PDFs and EPUBs with Vim-style navigation.",
-   "category": "Multimedia",
-   "stars": 81,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-06-15T13:07:11Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/Han8931/gorae@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/Han8931/gorae && cd gorae",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "act3",
    "url": "https://github.com/dhth/act3",
    "description": "Glance at the last 3 runs of your Github Actions",
@@ -27934,7 +27961,7 @@
    "url": "https://github.com/rubysolo/brows",
    "description": "CLI GitHub release browser",
    "category": "Development",
-   "stars": 78,
+   "stars": 79,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-06-01T14:33:35Z",
@@ -27964,7 +27991,7 @@
    "url": "https://github.com/ebithril/relax-player",
    "description": "A lightweight, distraction-free alternative to web-based ambient players.",
    "category": "Multimedia",
-   "stars": 77,
+   "stars": 78,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-01-05T07:50:02Z",
@@ -28006,7 +28033,7 @@
    "stars": 74,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-06-28T15:07:40Z",
+   "pushed_at": "2026-07-25T07:50:59Z",
    "methods": [
     {
      "kind": "cargo",
@@ -28029,6 +28056,36 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/hill/lazyslurm && cd lazyslurm",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "ls-horizons",
+   "url": "https://github.com/litescript/ls-horizons",
+   "description": "Terminal UI for visualizing NASA's Deep Space Network in real-time",
+   "category": "Dashboards",
+   "stars": 73,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-04-20T21:02:42Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/litescript/ls-horizons@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/litescript/ls-horizons && cd ls-horizons",
      "source": "inferred",
      "requires": [
       "git"
@@ -28077,41 +28134,11 @@
    ]
   },
   {
-   "name": "ls-horizons",
-   "url": "https://github.com/litescript/ls-horizons",
-   "description": "Terminal UI for visualizing NASA's Deep Space Network in real-time",
-   "category": "Dashboards",
-   "stars": 71,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-04-20T21:02:42Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/litescript/ls-horizons@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/litescript/ls-horizons && cd ls-horizons",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "terminal_gameboy",
    "url": "https://github.com/dquigles/terminal_gameboy",
    "description": "",
    "category": "Games",
-   "stars": 71,
+   "stars": 72,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-06-23T19:13:55Z",
@@ -28151,6 +28178,45 @@
       "brew"
      ],
      "note": "homebrew"
+    }
+   ]
+  },
+  {
+   "name": "rfc_reader",
+   "url": "https://github.com/ozan2003/rfc_reader",
+   "description": "A tool to read RFCs (Request for Comments) with a TUI, allowing you to fetch, cache, and browse RFC documents.",
+   "category": "Web",
+   "stars": 71,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-25T15:42:17Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install rfc_reader",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall rfc_reader",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/ozan2003/rfc_reader && cd rfc_reader",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
     }
    ]
   },
@@ -28196,50 +28262,11 @@
    ]
   },
   {
-   "name": "rfc_reader",
-   "url": "https://github.com/ozan2003/rfc_reader",
-   "description": "A tool to read RFCs (Request for Comments) with a TUI, allowing you to fetch, cache, and browse RFC documents.",
-   "category": "Web",
-   "stars": 70,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-06-17T17:12:58Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install rfc_reader",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall rfc_reader",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/ozan2003/rfc_reader && cd rfc_reader",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "tui-shop",
    "url": "https://github.com/Gcat101/tui-shop",
    "description": "Something between a CLI and a GUI way of downloading TUIs/CLIs",
    "category": "Miscellaneous",
-   "stars": 69,
+   "stars": 70,
    "language": "Python",
    "archived": false,
    "pushed_at": "2022-07-10T16:13:36Z",
@@ -28281,7 +28308,7 @@
    "stars": 68,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-20T16:04:40Z",
+   "pushed_at": "2026-07-20T23:47:00Z",
    "methods": [
     {
      "kind": "cargo",
@@ -28313,32 +28340,11 @@
    ]
   },
   {
-   "name": "toolui",
-   "url": "https://github.com/jinek/ToolUI",
-   "description": "Dotnet core application to manage installed nuget tools",
-   "category": "Development",
-   "stars": 66,
-   "language": "C#",
-   "archived": false,
-   "pushed_at": "2022-10-29T12:26:43Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/jinek/ToolUI && cd ToolUI",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "tododo",
    "url": "https://github.com/bmarse/tododo",
    "description": "A pretty TUI TODO.md manager for tasks and projects",
    "category": "Productivity",
-   "stars": 66,
+   "stars": 67,
    "language": "Go",
    "archived": false,
    "pushed_at": "2025-09-05T20:06:50Z",
@@ -28355,6 +28361,27 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/bmarse/tododo && cd tododo",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "toolui",
+   "url": "https://github.com/jinek/ToolUI",
+   "description": "Dotnet core application to manage installed nuget tools",
+   "category": "Development",
+   "stars": 66,
+   "language": "C#",
+   "archived": false,
+   "pushed_at": "2022-10-29T12:26:43Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/jinek/ToolUI && cd ToolUI",
      "source": "inferred",
      "requires": [
       "git"
@@ -28394,35 +28421,14 @@
    ]
   },
   {
-   "name": "pkm",
-   "url": "https://github.com/wick3dr0se/pkm",
-   "description": "A super minimal TUI package manager wrapper written in BASH v4.2+",
-   "category": "Productivity",
-   "stars": 63,
-   "language": "Shell",
-   "archived": false,
-   "pushed_at": "2024-06-17T12:56:11Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/wick3dr0se/pkm && cd pkm",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "nls",
    "url": "https://github.com/nolight132/nls",
    "description": "A modern ls with useful tables",
    "category": "CLI Tools",
-   "stars": 63,
+   "stars": 65,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-18T20:25:14Z",
+   "pushed_at": "2026-07-21T12:30:32Z",
    "methods": [
     {
      "kind": "yay",
@@ -28489,15 +28495,27 @@
       "git"
      ],
      "note": "then build per the README"
-    },
+    }
+   ]
+  },
+  {
+   "name": "pkm",
+   "url": "https://github.com/wick3dr0se/pkm",
+   "description": "A super minimal TUI package manager wrapper written in BASH v4.2+",
+   "category": "Productivity",
+   "stars": 64,
+   "language": "Shell",
+   "archived": false,
+   "pushed_at": "2024-06-17T12:56:11Z",
+   "methods": [
     {
-     "kind": "brew",
-     "command": "brew install nls",
+     "kind": "source",
+     "command": "git clone https://github.com/wick3dr0se/pkm && cd pkm",
      "source": "inferred",
      "requires": [
-      "brew"
+      "git"
      ],
-     "note": "homebrew"
+     "note": "then build per the README"
     }
    ]
   },
@@ -28587,7 +28605,7 @@
    "stars": 62,
    "language": "JavaScript",
    "archived": false,
-   "pushed_at": "2026-04-20T23:27:39Z",
+   "pushed_at": "2026-07-25T21:19:15Z",
    "methods": [
     {
      "kind": "npm",
@@ -28684,7 +28702,7 @@
    "url": "https://github.com/anistark/sot",
    "description": "A top like system observability tool written in python",
    "category": "Development",
-   "stars": 57,
+   "stars": 58,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-06-07T06:06:58Z",
@@ -28724,7 +28742,7 @@
    "url": "https://github.com/xqtr/markln",
    "description": "A terminal-based markdown editor built with Textual.",
    "category": "Editors",
-   "stars": 57,
+   "stars": 58,
    "language": "Python",
    "archived": false,
    "pushed_at": "2026-04-05T06:51:36Z",
@@ -28764,7 +28782,7 @@
    "url": "https://github.com/h-sifat/productivity-timer",
    "description": "A command line time tracker application with a sleek TUI.",
    "category": "Productivity",
-   "stars": 57,
+   "stars": 58,
    "language": "TypeScript",
    "archived": false,
    "pushed_at": "2026-05-15T18:15:00Z",
@@ -28836,7 +28854,7 @@
    "url": "https://github.com/zorig/valvefm",
    "description": "Vintage FM radio TUI for streaming stations from radio-browser.info",
    "category": "Multimedia",
-   "stars": 49,
+   "stars": 50,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-03-17T11:09:16Z",
@@ -28853,6 +28871,37 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/zorig/valvefm && cd valvefm",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "differ",
+   "url": "https://github.com/JanSmrcka/differ",
+   "description": "A TUI git diff viewer",
+   "category": "Development",
+   "stars": 49,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-08T07:17:34Z",
+   "homepage": "https://github.com/JanSmrcka/differ",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/JanSmrcka/differ@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/JanSmrcka/differ && cd differ",
      "source": "inferred",
      "requires": [
       "git"
@@ -28892,67 +28941,18 @@
    ]
   },
   {
-   "name": "searxngr",
-   "url": "https://github.com/scross01/searxngr",
-   "description": "Web search TUI for SearXNG",
-   "category": "Web",
-   "stars": 48,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2026-06-22T23:32:07Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install searxngr",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install searxngr",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/scross01/searxngr && cd searxngr",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "differ",
-   "url": "https://github.com/JanSmrcka/differ",
-   "description": "A TUI git diff viewer",
-   "category": "Development",
+   "name": "termrex",
+   "url": "https://github.com/SATYADAHAL/termrex",
+   "description": "A terminal-based endless runner game inspired by the Chrome Dino offline game.",
+   "category": "Games",
    "stars": 47,
-   "language": "Go",
+   "language": "C++",
    "archived": false,
-   "pushed_at": "2026-07-08T07:17:34Z",
-   "homepage": "https://github.com/JanSmrcka/differ",
+   "pushed_at": "2026-02-22T14:41:50Z",
    "methods": [
     {
-     "kind": "go",
-     "command": "go install github.com/JanSmrcka/differ@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
      "kind": "source",
-     "command": "git clone https://github.com/JanSmrcka/differ && cd differ",
+     "command": "git clone https://github.com/SATYADAHAL/termrex && cd termrex",
      "source": "inferred",
      "requires": [
       "git"
@@ -28990,11 +28990,50 @@
    "language": "Java",
    "stars": 47,
    "archived": false,
-   "pushed_at": "2026-07-20T16:30:08Z",
+   "pushed_at": "2026-07-25T00:53:55Z",
    "methods": [
     {
      "kind": "source",
      "command": "git clone https://github.com/crramirez/casciian && cd casciian",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "searxngr",
+   "url": "https://github.com/scross01/searxngr",
+   "description": "Web search TUI for SearXNG",
+   "category": "Web",
+   "stars": 47,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2026-06-22T23:32:07Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install searxngr",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install searxngr",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/scross01/searxngr && cd searxngr",
      "source": "inferred",
      "requires": [
       "git"
@@ -29082,18 +29121,28 @@
    ]
   },
   {
-   "name": "termrex",
-   "url": "https://github.com/SATYADAHAL/termrex",
-   "description": "A terminal-based endless runner game inspired by the Chrome Dino offline game.",
-   "category": "Games",
+   "name": "microNeo",
+   "url": "https://github.com/sollawen/microNeo",
+   "description": "A fork of Micro with in-place Markdown rendering — view and edit in the same window",
+   "category": "Editors",
    "stars": 45,
-   "language": "C++",
+   "language": "Go",
    "archived": false,
-   "pushed_at": "2026-02-22T14:41:50Z",
+   "pushed_at": "2026-07-25T13:08:52Z",
+   "homepage": "https://sollawen.github.io/microNeo/",
    "methods": [
     {
+     "kind": "go",
+     "command": "go install github.com/sollawen/microNeo@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
      "kind": "source",
-     "command": "git clone https://github.com/SATYADAHAL/termrex && cd termrex",
+     "command": "git clone https://github.com/sollawen/microNeo && cd microNeo",
      "source": "inferred",
      "requires": [
       "git"
@@ -29197,7 +29246,7 @@
    "stars": 42,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-19T17:39:50Z",
+   "pushed_at": "2026-07-24T19:01:28Z",
    "methods": [
     {
      "kind": "cargo",
@@ -29299,6 +29348,46 @@
    ]
   },
   {
+   "name": "rxpipes",
+   "url": "https://github.com/inunix3/rxpipes",
+   "description": "2D recreation of the ancient Pipes screensaver for terminals.",
+   "category": "Screensavers",
+   "stars": 41,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2024-09-07T12:57:40Z",
+   "homepage": "https://crates.io/crates/rxpipes",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install rxpipes",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall rxpipes",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/inunix3/rxpipes && cd rxpipes",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "logshark",
    "url": "https://github.com/ugosan/logshark",
    "description": "A debugger CLI for JSON logs written in Go",
@@ -29320,37 +29409,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/ugosan/logshark && cd logshark",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "microNeo",
-   "url": "https://github.com/sollawen/microNeo",
-   "description": "A fork of Micro with in-place Markdown rendering — view and edit in the same window",
-   "category": "Editors",
-   "stars": 40,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-20T09:45:47Z",
-   "homepage": "https://sollawen.github.io/microNeo/",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/sollawen/microNeo@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/sollawen/microNeo && cd microNeo",
      "source": "inferred",
      "requires": [
       "git"
@@ -29399,46 +29457,6 @@
    ]
   },
   {
-   "name": "rxpipes",
-   "url": "https://github.com/inunix3/rxpipes",
-   "description": "2D recreation of the ancient Pipes screensaver for terminals.",
-   "category": "Screensavers",
-   "stars": 40,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2024-09-07T12:57:40Z",
-   "homepage": "https://crates.io/crates/rxpipes",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install rxpipes",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall rxpipes",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/inunix3/rxpipes && cd rxpipes",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "dprs",
    "url": "https://github.com/durableprogramming/dprs",
    "description": "A TUI for managing Docker containers with real-time monitoring and log streaming",
@@ -29478,6 +29496,66 @@
    ]
   },
   {
+   "name": "Chronos",
+   "url": "https://github.com/samuelstranges/chronos",
+   "description": "A Vimlike Calendar TUI",
+   "category": "Productivity",
+   "stars": 39,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-04-23T07:34:27Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/samuelstranges/chronos@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/samuelstranges/chronos && cd chronos",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "drako",
+   "url": "https://github.com/lucky7xz/drako",
+   "description": "A grid-based, customizable and extendable command- and TUI-Deck launcher",
+   "category": "Productivity",
+   "stars": 39,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-22T15:17:37Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/lucky7xz/drako@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/lucky7xz/drako && cd drako",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "vctui",
    "url": "https://github.com/thebsdbox/vctui",
    "description": "Console interface for vCenter",
@@ -29499,36 +29577,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/thebsdbox/vctui && cd vctui",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "Chronos",
-   "url": "https://github.com/samuelstranges/chronos",
-   "description": "A Vimlike Calendar TUI",
-   "category": "Productivity",
-   "stars": 38,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-04-23T07:34:27Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/samuelstranges/chronos@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/samuelstranges/chronos && cd chronos",
      "source": "inferred",
      "requires": [
       "git"
@@ -29568,66 +29616,14 @@
    ]
   },
   {
-   "name": "Micro Snake",
-   "url": "https://github.com/troglobit/snake",
-   "description": "A small snake game, utilizing ANSI escape sequences to draw the board.",
-   "category": "Games",
-   "stars": 37,
-   "language": "C",
-   "archived": false,
-   "pushed_at": "2023-04-16T12:54:47Z",
-   "homepage": "http://troglobit.com/snake.html",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/troglobit/snake && cd snake",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "drako",
-   "url": "https://github.com/lucky7xz/drako",
-   "description": "A grid-based, customizable and extendable command- and TUI-Deck launcher",
-   "category": "Productivity",
-   "stars": 37,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-20T06:39:51Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/lucky7xz/drako@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/lucky7xz/drako && cd drako",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "qrypad",
    "url": "https://github.com/wheelibin/qrypad",
    "description": "A terminal SQL client for Postgres, MySQL and SQLite.",
    "category": "Development",
-   "stars": 36,
+   "stars": 37,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-06-22T11:39:33Z",
+   "pushed_at": "2026-07-23T21:27:01Z",
    "methods": [
     {
      "kind": "go",
@@ -29650,11 +29646,33 @@
    ]
   },
   {
+   "name": "Micro Snake",
+   "url": "https://github.com/troglobit/snake",
+   "description": "A small snake game, utilizing ANSI escape sequences to draw the board.",
+   "category": "Games",
+   "stars": 37,
+   "language": "C",
+   "archived": false,
+   "pushed_at": "2023-04-16T12:54:47Z",
+   "homepage": "http://troglobit.com/snake.html",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/troglobit/snake && cd snake",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "ytdl-tui",
    "url": "https://github.com/darky/ytdl-tui",
    "description": "TUI for downloading Youtube videos",
    "category": "Multimedia",
-   "stars": 35,
+   "stars": 36,
    "language": "TypeScript",
    "archived": false,
    "pushed_at": "2024-12-21T10:26:06Z",
@@ -29680,6 +29698,87 @@
    ]
   },
   {
+   "name": "ghostty-config-cli",
+   "url": "https://github.com/ajr-khll/ghostty-config-cli",
+   "description": "Fullscreen terminal UI for editing your Ghostty config, with a live preview of themes, fonts, colors, and cursor.",
+   "category": "Development",
+   "stars": 36,
+   "language": "TypeScript",
+   "archived": false,
+   "pushed_at": "2026-07-18T11:16:11Z",
+   "methods": [
+    {
+     "kind": "npm",
+     "command": "npm install -g ghostty-config-cli",
+     "source": "readme",
+     "requires": [
+      "npm"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/ajr-khll/ghostty-config-cli && cd ghostty-config-cli",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install ghostty-config-cli",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
+    }
+   ]
+  },
+  {
+   "name": "AnbUI",
+   "url": "https://github.com/oerg866/anbui",
+   "description": "A minimal Text UI Library in C",
+   "category": "Libraries",
+   "language": "C",
+   "stars": 35,
+   "archived": false,
+   "pushed_at": "2026-04-10T10:52:10Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/oerg866/anbui && cd anbui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "ServerHub",
+   "url": "https://github.com/nickprotop/ServerHub",
+   "description": "A TUI server monitoring dashboard for Linux with real-time metrics, scriptable widgets, and remote management",
+   "category": "Dashboards",
+   "stars": 34,
+   "language": "C#",
+   "archived": false,
+   "pushed_at": "2026-07-18T16:38:17Z",
+   "methods": [
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/nickprotop/ServerHub && cd ServerHub",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "deputui",
    "url": "https://github.com/twiddler/deputui",
    "description": "Review and install NPM package updates",
@@ -29687,7 +29786,7 @@
    "stars": 34,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-06-29T21:44:33Z",
+   "pushed_at": "2026-07-20T21:45:12Z",
    "methods": [
     {
      "kind": "cargo",
@@ -29719,18 +29818,36 @@
    ]
   },
   {
-   "name": "AnbUI",
-   "url": "https://github.com/oerg866/anbui",
-   "description": "A minimal Text UI Library in C",
-   "category": "Libraries",
-   "language": "C",
+   "name": "ani-l",
+   "url": "https://github.com/komposer-aml/ani-l",
+   "description": "Rust-based anime browsing and streaming all without leaving the terminal",
+   "category": "Multimedia",
    "stars": 34,
+   "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-04-10T10:52:10Z",
+   "pushed_at": "2026-01-08T00:42:47Z",
    "methods": [
     {
+     "kind": "cargo",
+     "command": "cargo install ani-l",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall ani-l",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
      "kind": "source",
-     "command": "git clone https://github.com/oerg866/anbui && cd anbui",
+     "command": "git clone https://github.com/komposer-aml/ani-l && cd ani-l",
      "source": "inferred",
      "requires": [
       "git"
@@ -29779,45 +29896,6 @@
    ]
   },
   {
-   "name": "typeinc",
-   "url": "https://github.com/AnirudhG07/Typeinc",
-   "description": "Ncurses based typing speed test with various difficulty levels.",
-   "category": "Games",
-   "stars": 33,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2025-06-28T06:08:51Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install typeinc",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install typeinc",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/AnirudhG07/Typeinc && cd Typeinc",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "rocket.term",
    "url": "https://github.com/gerstner-hub/rocket.term",
    "description": "Text based chat client for the Rocket.chat messaging solution.",
@@ -29857,66 +29935,6 @@
    ]
   },
   {
-   "name": "ani-l",
-   "url": "https://github.com/komposer-aml/ani-l",
-   "description": "Rust-based anime browsing and streaming all without leaving the terminal",
-   "category": "Multimedia",
-   "stars": 33,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-01-08T00:42:47Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install ani-l",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall ani-l",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/komposer-aml/ani-l && cd ani-l",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "ServerHub",
-   "url": "https://github.com/nickprotop/ServerHub",
-   "description": "A TUI server monitoring dashboard for Linux with real-time metrics, scriptable widgets, and remote management",
-   "category": "Dashboards",
-   "stars": 32,
-   "language": "C#",
-   "archived": false,
-   "pushed_at": "2026-07-18T16:38:17Z",
-   "methods": [
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/nickprotop/ServerHub && cd ServerHub",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "trek",
    "url": "https://github.com/franckverrot/trek",
    "description": "Ncurses explorer for Hashicorp Nomad clusters",
@@ -29938,6 +29956,45 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/franckverrot/trek && cd trek",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "typeinc",
+   "url": "https://github.com/AnirudhG07/Typeinc",
+   "description": "Ncurses based typing speed test with various difficulty levels.",
+   "category": "Games",
+   "stars": 32,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2025-06-28T06:08:51Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install typeinc",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install typeinc",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/AnirudhG07/Typeinc && cd Typeinc",
      "source": "inferred",
      "requires": [
       "git"
@@ -30044,7 +30101,7 @@
    "language": "Python",
    "stars": 31,
    "archived": false,
-   "pushed_at": "2026-05-21T08:43:39Z",
+   "pushed_at": "2026-07-21T14:56:52Z",
    "homepage": "https://argenta.readthedocs.io",
    "methods": [
     {
@@ -30081,7 +30138,7 @@
    "url": "https://github.com/MitchelPaulin/sudoku-rs",
    "description": "Sudoku built with tui-rs",
    "category": "Games",
-   "stars": 29,
+   "stars": 30,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2024-08-17T20:39:43Z",
@@ -30107,6 +30164,75 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/MitchelPaulin/sudoku-rs && cd sudoku-rs",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "terminal-pong",
+   "url": "https://github.com/IshmamR/terminal.pong",
+   "description": "A simple, fun ping pong game playable entirely in your terminal.",
+   "category": "Games",
+   "stars": 29,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2025-07-09T20:52:30Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install terminal.pong",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall terminal.pong",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/IshmamR/terminal.pong && cd terminal.pong",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "distrobox-tui",
+   "url": "https://github.com/phanirithvij/distrobox-tui",
+   "description": "TUI for managing distrobox containers",
+   "category": "Miscellaneous",
+   "stars": 29,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2025-03-11T16:32:04Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/phanirithvij/distrobox-tui@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/phanirithvij/distrobox-tui && cd distrobox-tui",
      "source": "inferred",
      "requires": [
       "git"
@@ -30176,66 +30302,37 @@
    ]
   },
   {
-   "name": "terminal-pong",
-   "url": "https://github.com/IshmamR/terminal.pong",
-   "description": "A simple, fun ping pong game playable entirely in your terminal.",
-   "category": "Games",
-   "stars": 28,
-   "language": "Rust",
+   "name": "thymus",
+   "url": "https://github.com/blademd/thymus",
+   "description": "An interactive browser & editor for network configuration files.",
+   "category": "Editors",
+   "stars": 27,
+   "language": "Python",
    "archived": false,
-   "pushed_at": "2025-07-09T20:52:30Z",
+   "pushed_at": "2024-06-04T14:19:56Z",
+   "homepage": "https://thymus.dev",
    "methods": [
     {
-     "kind": "cargo",
-     "command": "cargo install terminal.pong",
+     "kind": "uv",
+     "command": "uv tool install thymus",
      "source": "inferred",
      "requires": [
-      "cargo"
+      "uv"
      ],
      "note": "guessed from repo name"
     },
     {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall terminal.pong",
+     "kind": "pipx",
+     "command": "pipx install thymus",
      "source": "inferred",
      "requires": [
-      "cargo-binstall"
+      "pipx"
      ],
      "note": "guessed from repo name"
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/IshmamR/terminal.pong && cd terminal.pong",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "distrobox-tui",
-   "url": "https://github.com/phanirithvij/distrobox-tui",
-   "description": "TUI for managing distrobox containers",
-   "category": "Miscellaneous",
-   "stars": 28,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2025-03-11T16:32:04Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/phanirithvij/distrobox-tui@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/phanirithvij/distrobox-tui && cd distrobox-tui",
+     "command": "git clone https://github.com/blademd/thymus && cd thymus",
      "source": "inferred",
      "requires": [
       "git"
@@ -30275,46 +30372,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/ClaudioRMalvino/physics_TUI && cd physics_TUI",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "thymus",
-   "url": "https://github.com/blademd/thymus",
-   "description": "An interactive browser & editor for network configuration files.",
-   "category": "Editors",
-   "stars": 26,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2024-06-04T14:19:56Z",
-   "homepage": "https://thymus.dev",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install thymus",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install thymus",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/blademd/thymus && cd thymus",
      "source": "inferred",
      "requires": [
       "git"
@@ -30457,41 +30514,32 @@
    ]
   },
   {
-   "name": "ghostty-config-cli",
-   "url": "https://github.com/ajr-khll/ghostty-config-cli",
-   "description": "Fullscreen terminal UI for editing your Ghostty config, with a live preview of themes, fonts, colors, and cursor.",
-   "category": "Development",
-   "stars": 24,
-   "language": "TypeScript",
+   "name": "etcd-walker",
+   "url": "https://github.com/nexusriot/etcd-walker/",
+   "description": "Opensource TUI tool for managing etcd keys",
+   "category": "Docker/LXC/K8s",
+   "stars": 23,
+   "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-18T11:16:11Z",
+   "pushed_at": "2026-07-05T18:57:08Z",
    "methods": [
     {
-     "kind": "npm",
-     "command": "npm install -g ghostty-config-cli",
-     "source": "readme",
+     "kind": "go",
+     "command": "go install github.com/nexusriot/etcd-walker@latest",
+     "source": "inferred",
      "requires": [
-      "npm"
+      "go"
      ],
-     "note": "from README"
+     "note": "module path from repo"
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/ajr-khll/ghostty-config-cli && cd ghostty-config-cli",
+     "command": "git clone https://github.com/nexusriot/etcd-walker && cd etcd-walker",
      "source": "inferred",
      "requires": [
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install ghostty-config-cli",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -30527,18 +30575,18 @@
    ]
   },
   {
-   "name": "etcd-walker",
-   "url": "https://github.com/nexusriot/etcd-walker/",
-   "description": "Opensource TUI tool for managing etcd keys",
-   "category": "Docker/LXC/K8s",
+   "name": "sacha",
+   "url": "https://github.com/Sachamama/sacha",
+   "description": "A two-pane AWS TUI for browsing, searching, and managing resources across seven services including CloudWatch Logs, S3, DynamoDB, Lambda, SSM, SQS, and EC2.",
+   "category": "Dashboards",
    "stars": 22,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-05T18:57:08Z",
+   "pushed_at": "2026-06-22T22:38:15Z",
    "methods": [
     {
      "kind": "go",
-     "command": "go install github.com/nexusriot/etcd-walker@latest",
+     "command": "go install github.com/Sachamama/sacha@latest",
      "source": "inferred",
      "requires": [
       "go"
@@ -30547,7 +30595,7 @@
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/nexusriot/etcd-walker && cd etcd-walker",
+     "command": "git clone https://github.com/Sachamama/sacha && cd sacha",
      "source": "inferred",
      "requires": [
       "git"
@@ -30600,7 +30648,7 @@
    "url": "https://github.com/hjelev/lyrtui",
    "description": "Fast and good looking TUI for Lyrion Music Server",
    "category": "Multimedia",
-   "stars": 21,
+   "stars": 22,
    "language": "Rust",
    "archived": false,
    "pushed_at": "2026-07-08T17:24:06Z",
@@ -30641,15 +30689,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install lyrtui",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -30658,7 +30697,7 @@
    "url": "https://github.com/NubleX/ID-Spoofer",
    "description": "A cross-platform cybersecurity toolkit for fingerprint and traffic obfuscation.",
    "category": "Dashboards",
-   "stars": 20,
+   "stars": 21,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-03-01T00:06:17Z",
@@ -30685,44 +30724,14 @@
    ]
   },
   {
-   "name": "sacha",
-   "url": "https://github.com/Sachamama/sacha",
-   "description": "A two-pane AWS TUI for browsing, searching, and managing resources across seven services including CloudWatch Logs, S3, DynamoDB, Lambda, SSM, SQS, and EC2.",
-   "category": "Dashboards",
-   "stars": 20,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-06-22T22:38:15Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/Sachamama/sacha@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/Sachamama/sacha && cd sacha",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "Servonaut",
    "url": "https://github.com/zb-ss/servonaut",
    "description": "A TUI for managing AWS, Hetzner, OVH and custom SSH servers with log viewing, CloudWatch/CloudTrail browsing, IP banning, AI log analysis and a built-in MCP server",
    "category": "Dashboards",
-   "stars": 20,
+   "stars": 21,
    "language": "Python",
    "archived": false,
-   "pushed_at": "2026-07-18T22:18:43Z",
+   "pushed_at": "2026-07-25T00:19:06Z",
    "methods": [
     {
      "kind": "uv",
@@ -30754,6 +30763,45 @@
    ]
   },
   {
+   "name": "omaro",
+   "url": "https://github.com/Rolv-Apneseth/omaro",
+   "description": "TUI to browse posts and comments on lobste.rs",
+   "category": "Web",
+   "stars": 21,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-02-16T21:20:44Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install omaro",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall omaro",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/Rolv-Apneseth/omaro && cd omaro",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "SwarmCLI",
    "url": "https://github.com/Eldara-Tech/swarmcli",
    "description": "Swarm Management at the speed of thought — with real-time log streaming, instant shell access to containers, seamless port forwarding, and on-demand secret reveal capabilities, giving you full control over your Docker Swarm without breaking your flow.",
@@ -30761,7 +30809,7 @@
    "stars": 20,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-07-20T11:54:20Z",
+   "pushed_at": "2026-07-23T06:49:22Z",
    "homepage": "https://swarmcli.io/",
    "methods": [
     {
@@ -30806,36 +30854,36 @@
    ]
   },
   {
-   "name": "omaro",
-   "url": "https://github.com/Rolv-Apneseth/omaro",
-   "description": "TUI to browse posts and comments on lobste.rs",
-   "category": "Web",
+   "name": "HydroToDo",
+   "url": "https://github.com/Henriquehnnm/hydrotodo",
+   "description": "A simple and beautiful TUI to-do list",
+   "category": "Productivity",
    "stars": 20,
-   "language": "Rust",
+   "language": "Python",
    "archived": false,
-   "pushed_at": "2026-02-16T21:20:44Z",
+   "pushed_at": "2026-01-16T20:59:06Z",
    "methods": [
     {
-     "kind": "cargo",
-     "command": "cargo install omaro",
+     "kind": "uv",
+     "command": "uv tool install hydrotodo",
      "source": "inferred",
      "requires": [
-      "cargo"
+      "uv"
      ],
      "note": "guessed from repo name"
     },
     {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall omaro",
+     "kind": "pipx",
+     "command": "pipx install hydrotodo",
      "source": "inferred",
      "requires": [
-      "cargo-binstall"
+      "pipx"
      ],
      "note": "guessed from repo name"
     },
     {
      "kind": "source",
-     "command": "git clone https://github.com/Rolv-Apneseth/omaro && cd omaro",
+     "command": "git clone https://github.com/Henriquehnnm/hydrotodo && cd hydrotodo",
      "source": "inferred",
      "requires": [
       "git"
@@ -30992,45 +31040,6 @@
    ]
   },
   {
-   "name": "HydroToDo",
-   "url": "https://github.com/Henriquehnnm/hydrotodo",
-   "description": "A simple and beautiful TUI to-do list",
-   "category": "Productivity",
-   "stars": 19,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2026-01-16T20:59:06Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install hydrotodo",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install hydrotodo",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/Henriquehnnm/hydrotodo && cd hydrotodo",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "logradar",
    "url": "https://github.com/nanook72/logradar",
    "description": "A fast Rust TUI for interactive log filtering and highlighting.",
@@ -31061,6 +31070,36 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/nanook72/logradar && cd logradar",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "docker-dash",
+   "url": "https://github.com/GustavoCaso/docker-dash",
+   "description": "A full TUI managemnet tool for Docker",
+   "category": "Docker/LXC/K8s",
+   "stars": 18,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-07-25T04:02:50Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/GustavoCaso/docker-dash@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/GustavoCaso/docker-dash && cd docker-dash",
      "source": "inferred",
      "requires": [
       "git"
@@ -31140,36 +31179,6 @@
    ]
   },
   {
-   "name": "docker-dash",
-   "url": "https://github.com/GustavoCaso/docker-dash",
-   "description": "A full TUI managemnet tool for Docker",
-   "category": "Docker/LXC/K8s",
-   "stars": 17,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-07-19T12:48:36Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/GustavoCaso/docker-dash@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/GustavoCaso/docker-dash && cd docker-dash",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "lazynginx",
    "url": "https://github.com/giacomomasseron/lazynginx",
    "description": "Simple TUI for nginx management.",
@@ -31191,6 +31200,36 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/giacomomasseron/lazynginx && cd lazynginx",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "sq",
+   "url": "https://github.com/sheenazien8/sq",
+   "description": "A database client specially made for vim users",
+   "category": "Development",
+   "stars": 16,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2026-02-25T08:19:26Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/sheenazien8/sq@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/sheenazien8/sq && cd sq",
      "source": "inferred",
      "requires": [
       "git"
@@ -31294,36 +31333,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/RauliL/levite && cd levite",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "sq",
-   "url": "https://github.com/sheenazien8/sq",
-   "description": "A database client specially made for vim users",
-   "category": "Development",
-   "stars": 14,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2026-02-25T08:19:26Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/sheenazien8/sq@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/sheenazien8/sq && cd sq",
      "source": "inferred",
      "requires": [
       "git"
@@ -31450,50 +31459,11 @@
    ]
   },
   {
-   "name": "pream-team",
-   "url": "https://github.com/nikoladucak/pream-team/",
-   "description": "A TUI utility that helps you keep track of your teams GitHub PRs across multiple repositories",
-   "category": "Productivity",
-   "stars": 13,
-   "language": "Python",
-   "archived": false,
-   "pushed_at": "2024-02-26T14:24:29Z",
-   "methods": [
-    {
-     "kind": "uv",
-     "command": "uv tool install pream-team",
-     "source": "inferred",
-     "requires": [
-      "uv"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "pipx",
-     "command": "pipx install pream-team",
-     "source": "inferred",
-     "requires": [
-      "pipx"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/nikoladucak/pream-team && cd pream-team",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "wlocks",
    "url": "https://github.com/programmersd21/wlocks",
    "description": "📂 see which processes hold your files open: a smooth tui alternative to lsof/fuser with auto-refresh, fuzzy search, sort modes, and themes",
    "category": "Dashboards",
-   "stars": 13,
+   "stars": 14,
    "language": "Go",
    "archived": false,
    "pushed_at": "2026-07-15T11:26:09Z",
@@ -31543,6 +31513,45 @@
    ]
   },
   {
+   "name": "pream-team",
+   "url": "https://github.com/nikoladucak/pream-team/",
+   "description": "A TUI utility that helps you keep track of your teams GitHub PRs across multiple repositories",
+   "category": "Productivity",
+   "stars": 13,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2024-02-26T14:24:29Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install pream-team",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install pream-team",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/nikoladucak/pream-team && cd pream-team",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "catalyst",
    "url": "https://github.com/PraveenGongada/catalyst",
    "description": "Elegant TUI for triggering GitHub Actions workflows with matrix configurations.",
@@ -31580,7 +31589,7 @@
    "stars": 12,
    "language": "C",
    "archived": false,
-   "pushed_at": "2026-07-20T14:56:13Z",
+   "pushed_at": "2026-07-26T00:54:08Z",
    "homepage": "https://github.com/robkam/ytreenova",
    "methods": [
     {
@@ -31608,6 +31617,45 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/WilliamAGH/brief && cd brief",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "UniPac",
+   "url": "https://github.com/jesper-olsen/UniPac",
+   "description": "Unicode-powered Pac-Man for the terminal, written in Rust.",
+   "category": "Games",
+   "stars": 11,
+   "language": "Rust",
+   "archived": false,
+   "pushed_at": "2026-07-22T04:51:06Z",
+   "methods": [
+    {
+     "kind": "cargo",
+     "command": "cargo install unipac",
+     "source": "inferred",
+     "requires": [
+      "cargo"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "cargo-binstall",
+     "command": "cargo binstall unipac",
+     "source": "inferred",
+     "requires": [
+      "cargo-binstall"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/jesper-olsen/UniPac && cd UniPac",
      "source": "inferred",
      "requires": [
       "git"
@@ -31708,45 +31756,6 @@
    ]
   },
   {
-   "name": "UniPac",
-   "url": "https://github.com/jesper-olsen/UniPac",
-   "description": "Unicode-powered Pac-Man for the terminal, written in Rust.",
-   "category": "Games",
-   "stars": 10,
-   "language": "Rust",
-   "archived": false,
-   "pushed_at": "2026-05-07T20:57:06Z",
-   "methods": [
-    {
-     "kind": "cargo",
-     "command": "cargo install unipac",
-     "source": "inferred",
-     "requires": [
-      "cargo"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "cargo-binstall",
-     "command": "cargo binstall unipac",
-     "source": "inferred",
-     "requires": [
-      "cargo-binstall"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/jesper-olsen/UniPac && cd UniPac",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "ttm",
    "url": "https://github.com/vst93/ttm",
    "description": "SSH bookmark manager with Bubble Tea TUI — connect, manage and sync via Gist",
@@ -31754,7 +31763,7 @@
    "stars": 10,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-06-22T08:28:16Z",
+   "pushed_at": "2026-07-24T20:42:26Z",
    "methods": [
     {
      "kind": "go",
@@ -31844,7 +31853,7 @@
    "stars": 9,
    "language": "Go",
    "archived": false,
-   "pushed_at": "2026-06-14T06:54:51Z",
+   "pushed_at": "2026-07-23T14:44:13Z",
    "methods": [
     {
      "kind": "go",
@@ -31867,6 +31876,36 @@
    ]
   },
   {
+   "name": "gokemon",
+   "url": "https://github.com/nathanieltooley/gokemon",
+   "description": "A terminal based Pokemon battle simulator",
+   "category": "Games",
+   "stars": 9,
+   "language": "Go",
+   "archived": false,
+   "pushed_at": "2025-10-31T16:17:24Z",
+   "methods": [
+    {
+     "kind": "go",
+     "command": "go install github.com/nathanieltooley/gokemon@latest",
+     "source": "inferred",
+     "requires": [
+      "go"
+     ],
+     "note": "module path from repo"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/nathanieltooley/gokemon && cd gokemon",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "GGUI",
    "url": "https://github.com/Gabidal/GGUI",
    "description": "C++17 Structured Terminal User Interface. 🐧/🪟",
@@ -31874,7 +31913,7 @@
    "language": "C++",
    "stars": 9,
    "archived": false,
-   "pushed_at": "2026-07-20T05:43:18Z",
+   "pushed_at": "2026-07-24T12:12:01Z",
    "homepage": "https://gabidal.github.io/GGUI-Document/",
    "methods": [
     {
@@ -31958,36 +31997,6 @@
    ]
   },
   {
-   "name": "gokemon",
-   "url": "https://github.com/nathanieltooley/gokemon",
-   "description": "A terminal based Pokemon battle simulator",
-   "category": "Games",
-   "stars": 8,
-   "language": "Go",
-   "archived": false,
-   "pushed_at": "2025-10-31T16:17:24Z",
-   "methods": [
-    {
-     "kind": "go",
-     "command": "go install github.com/nathanieltooley/gokemon@latest",
-     "source": "inferred",
-     "requires": [
-      "go"
-     ],
-     "note": "module path from repo"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/nathanieltooley/gokemon && cd gokemon",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
    "name": "tuidict",
    "url": "https://github.com/404Simon/tuidict",
    "description": "Fast offline dictionary with in-app downloads and multi-language support from FreeDict",
@@ -31995,7 +32004,7 @@
    "stars": 8,
    "language": "Rust",
    "archived": false,
-   "pushed_at": "2026-07-19T20:40:09Z",
+   "pushed_at": "2026-07-23T10:16:09Z",
    "methods": [
     {
      "kind": "cargo",
@@ -32096,6 +32105,94 @@
    ]
   },
   {
+   "name": "onepace",
+   "url": "https://github.com/vashhdev/onepace",
+   "description": "I made a script to watch One Pace, efficiently through your terminal with minimalistic TUI. I made it because I didn't want to download the files cause I watch quickly and then remove those files, also I love my local player \"mpv\". What more reasons do you need. Let's sail",
+   "category": "Multimedia",
+   "stars": 7,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2026-07-25T06:02:11Z",
+   "methods": [
+    {
+     "kind": "pipx",
+     "command": "pipx install git+https://github.com/vashhdev/onepace",
+     "source": "readme",
+     "requires": [
+      "pipx"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "uv",
+     "command": "uv tool install git+https://github.com/vashhdev/onepace",
+     "source": "readme",
+     "requires": [
+      "uv"
+     ],
+     "note": "from README"
+    },
+    {
+     "kind": "uv",
+     "command": "uv tool install onepace",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install onepace",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/vashhdev/onepace && cd onepace",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "kagan",
+   "url": "https://github.com/kagan-sh/kagan",
+   "description": "AI-powered Kanban TUI for autonomous development workflows",
+   "category": "Development",
+   "stars": 6,
+   "language": "TypeScript",
+   "archived": false,
+   "pushed_at": "2026-07-21T15:45:30Z",
+   "homepage": "http://kagan.sh",
+   "methods": [
+    {
+     "kind": "npm",
+     "command": "npm install -g kagan",
+     "source": "inferred",
+     "requires": [
+      "npm"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/kagan-sh/kagan && cd kagan",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    }
+   ]
+  },
+  {
    "name": "LogLens",
    "url": "https://github.com/Caelrith/loglens-core",
    "description": "A structured log viewer and query engine for the terminal.",
@@ -32126,37 +32223,6 @@
     {
      "kind": "source",
      "command": "git clone https://github.com/Caelrith/loglens-core && cd loglens-core",
-     "source": "inferred",
-     "requires": [
-      "git"
-     ],
-     "note": "then build per the README"
-    }
-   ]
-  },
-  {
-   "name": "kagan",
-   "url": "https://github.com/kagan-sh/kagan",
-   "description": "AI-powered Kanban TUI for autonomous development workflows",
-   "category": "Development",
-   "stars": 5,
-   "language": "TypeScript",
-   "archived": false,
-   "pushed_at": "2026-07-17T08:42:50Z",
-   "homepage": "http://kagan.sh",
-   "methods": [
-    {
-     "kind": "npm",
-     "command": "npm install -g kagan",
-     "source": "inferred",
-     "requires": [
-      "npm"
-     ],
-     "note": "guessed from repo name"
-    },
-    {
-     "kind": "source",
-     "command": "git clone https://github.com/kagan-sh/kagan && cd kagan",
      "source": "inferred",
      "requires": [
       "git"
@@ -32392,15 +32458,6 @@
       "git"
      ],
      "note": "then build per the README"
-    },
-    {
-     "kind": "brew",
-     "command": "brew install sb",
-     "source": "inferred",
-     "requires": [
-      "brew"
-     ],
-     "note": "homebrew"
     }
    ]
   },
@@ -32433,7 +32490,7 @@
    "language": "C++",
    "stars": 1,
    "archived": false,
-   "pushed_at": "2026-07-20T02:55:49Z",
+   "pushed_at": "2026-07-25T20:04:57Z",
    "methods": [
     {
      "kind": "source",
@@ -32473,6 +32530,54 @@
       "git"
      ],
      "note": "then build per the README"
+    }
+   ]
+  },
+  {
+   "name": "soundcloud-tui",
+   "url": "https://github.com/laguser/soundcloud-tui",
+   "description": "",
+   "category": "Multimedia",
+   "stars": 1,
+   "language": "Python",
+   "archived": false,
+   "pushed_at": "2025-12-03T16:45:20Z",
+   "methods": [
+    {
+     "kind": "uv",
+     "command": "uv tool install soundcloud-tui",
+     "source": "inferred",
+     "requires": [
+      "uv"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "pipx",
+     "command": "pipx install soundcloud-tui",
+     "source": "inferred",
+     "requires": [
+      "pipx"
+     ],
+     "note": "guessed from repo name"
+    },
+    {
+     "kind": "source",
+     "command": "git clone https://github.com/laguser/soundcloud-tui && cd soundcloud-tui",
+     "source": "inferred",
+     "requires": [
+      "git"
+     ],
+     "note": "then build per the README"
+    },
+    {
+     "kind": "brew",
+     "command": "brew install soundcloud-tui",
+     "source": "inferred",
+     "requires": [
+      "brew"
+     ],
+     "note": "homebrew"
     }
    ]
   },


### PR DESCRIPTION
## Summary

Adds three tools to the catalog as regular `ESSENTIALS` entries (not `FEATURED`), following this session's established pattern.

| Tool | URL | Category | Stars | Install (verified from README) |
|---|---|---|---|---|
| stocksTUI | github.com/andriy-git/stocksTUI | Dashboards | 156 | `pipx install stocksTUI` (scraped verbatim from README) |
| soundcloud-tui | github.com/laguser/soundcloud-tui | Multimedia | 1 | source-only: `git clone` + venv + `pip install textual pygame-ce yt-dlp requests` + `python install.py` (documented in README; see note below) |
| onepace | github.com/vashhdev/onepace | Multimedia | 7 | `pipx install git+https://github.com/vashhdev/onepace` and `uv tool install git+https://github.com/vashhdev/onepace` (both scraped verbatim from README) |

Closes #32 (onepace — filed by the tool's own author, vashhdev, describing the interactive terminal picker for streaming One Pace arcs into mpv).

## Notes

- **soundcloud-tui**: its README documents a real, working install (clone + venv + `pip install` deps + `python install.py`), but that multi-step recipe isn't a single classifiable command, so the automated README scraper can't lift it verbatim. The catalog therefore carries the pipeline's standard clearly-labeled `inferred`/"guessed from repo name" pipx/uv fallbacks plus the honest bare-`git clone` fallback, rather than a fabricated single-line install — same treatment every other unscrapable README gets in this catalog. Flagging this explicitly rather than letting it pass silently.
- **onepace**: the issue author explicitly confirmed no Homebrew formula exists. The existing `build_catalog.py` pipeline auto-guesses a `brew install <repo>` fallback for every `ESSENTIALS` entry, which would have fabricated one here — so this PR adds a small `ESSENTIAL_NO_BREW` opt-out set (currently just `vashhdev/onepace`) to suppress that guess for this entry specifically. No other essentials are affected.
- Verified via `gh api repos/<owner>/<repo> --jq .full_name` that none of the three have been through a GitHub org transfer (all three `full_name` values match their current owner/repo exactly).

## Verification

- Catalog regenerated via `uv run python tools/build_catalog.py`: **819 → 822 entries** (net +3, exactly the three additions — confirmed via before/after diff on exact URL, exact name, and by-slug via `tuistore.installer.parse_repo`).
- Zero new duplicates: no exact-URL dupes, no new by-slug collisions. One pre-existing by-slug collision (`learnbyexample/TUI-apps` vs. its `/tree/main/SquareTicTacToe` subpath URL) was confirmed present on `main` *before* this change (819 raw → 818 unique slugs already on main) — unrelated to this PR, not touched.
- Full test suite: `uv run python -m unittest discover tests -v` → **153 tests, all passing**.
- Import sanity check passes (`tuistore.app`, `tuistore.__main__`, `tuistore.installed`, `tuistore.catalog`, `tuistore.installer`, `tuistore.scrape`, `tuistore.github`, `tuistore.platform`).
- Catalog load + duplicate-slug check passes: `len(cat.entries) == 821` (post load-time dedupe of the one pre-existing collision above), all slugs unique.

## Test plan

- [x] `uv run python tools/build_catalog.py` regenerates cleanly
- [x] `uv run python -m unittest discover tests -v` — 153 passed
- [x] Import + catalog-load/dedupe-slug sanity checks pass
- [x] Before/after entry-count diff + duplicate scan (URL, name, slug) confirms exactly 3 new entries, 0 unrelated changes
- [x] CI green on this branch