### PR TITLE
Hand the real terminal over for sudo/AUR-helper commands

### DIFF
--- a/tests/test_install_modal.py
+++ b/tests/test_install_modal.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest.mock import Mock
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
 
 from ricekit import KitApp
 from textual.widgets import OptionList
@@ -8,6 +9,14 @@ from tuistore.app import InstallModal
 from tuistore.catalog import Entry
 from tuistore.installer import make
 from tuistore.platform import Env
+
+
+@contextmanager
+def _noop_suspend():
+    """Stand-in for `App.suspend()` -- real suspension takes over the actual
+    terminal, which Textual's headless `run_test()` harness can't exercise
+    in CI, so tests patch it out with a context manager that does nothing."""
+    yield
 
 
 class Harness(KitApp):
@@ -51,6 +60,109 @@ class InstallModalAvailabilityTest(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(modal.running)
             modal._install.assert_not_called()
             app.notify.assert_called_once_with("needs cargo-binstall", severity="warning")
+
+
+class InstallModalTerminalHandoffTest(unittest.IsolatedAsyncioTestCase):
+    """github.com/Gheat1/tuistore/issues/31: `run_stream`'s piped stdout
+    never wires up the child's stdin, so a command that prompts on the
+    terminal (a sudo password, an AUR helper confirmation) can't receive
+    it. A command flagged by `is_interactive_command` must instead hand the
+    real terminal over via `App.suspend()` and run with fully inherited
+    stdio -- no captured pipes at all -- while a plain, non-interactive
+    command must keep using the normal streamed `run_stream` path and must
+    never suspend the app."""
+
+    def setUp(self) -> None:
+        self.entry = Entry("haal", "https://github.com/example/haal")
+
+    async def test_sudo_command_suspends_and_runs_with_inherited_stdio(self) -> None:
+        method = make("pacman", "sudo pacman -S haal")
+        modal = InstallModal(self.entry, method, [])
+        app = Harness()
+        app.env = Env("linux", "arch", {"arch"}, tools={"pacman"})
+        app.notify = Mock()
+        # exit non-zero so `_install` never reaches `self.app.on_installed`,
+        # which this bare test harness (unlike the real StoreApp) doesn't
+        # implement -- irrelevant to what this test is checking.
+        fake_proc = Mock(returncode=1)
+
+        with patch.object(app, "suspend", side_effect=_noop_suspend) as suspend_mock, \
+             patch("tuistore.app.subprocess.run", return_value=fake_proc) as run_mock, \
+             patch("tuistore.app.run_stream") as stream_mock:
+            async with app.run_test() as pilot:
+                app.push_screen(modal)
+                await pilot.pause()
+                modal.action_run()
+                await pilot.pause()
+                await pilot.pause()
+                await pilot.pause()
+
+        suspend_mock.assert_called_once()
+        run_mock.assert_called_once()
+        stream_mock.assert_not_called()
+        # fully inherited stdio -- no captured pipes of any kind
+        _, kwargs = run_mock.call_args
+        self.assertNotIn("stdout", kwargs)
+        self.assertNotIn("stderr", kwargs)
+        self.assertNotIn("stdin", kwargs)
+        argv = run_mock.call_args.args[0]
+        self.assertIn("sudo pacman -S haal", argv[-1])
+        self.assertFalse(modal.running)
+        self.assertTrue(modal.done)
+
+    async def test_yay_command_suspends_even_without_sudo(self) -> None:
+        method = make("yay", "yay -S haal")
+        modal = InstallModal(self.entry, method, [])
+        app = Harness()
+        app.env = Env("linux", "arch", {"arch"}, tools={"yay"})
+        app.notify = Mock()
+        fake_proc = Mock(returncode=1)
+
+        with patch.object(app, "suspend", side_effect=_noop_suspend) as suspend_mock, \
+             patch("tuistore.app.subprocess.run", return_value=fake_proc) as run_mock, \
+             patch("tuistore.app.run_stream") as stream_mock:
+            async with app.run_test() as pilot:
+                app.push_screen(modal)
+                await pilot.pause()
+                modal.action_run()
+                await pilot.pause()
+                await pilot.pause()
+                await pilot.pause()
+
+        suspend_mock.assert_called_once()
+        run_mock.assert_called_once()
+        stream_mock.assert_not_called()
+
+    async def test_non_interactive_command_streams_and_never_suspends(self) -> None:
+        method = make("cargo", "cargo install haal")
+        modal = InstallModal(self.entry, method, [])
+        app = Harness()
+        app.env = Env("linux", "arch", {"arch"}, tools={"cargo"})
+        app.notify = Mock()
+
+        async def fake_stream(command):
+            yield ("out", "compiling...")
+            yield ("exit", "1")
+
+        with patch.object(app, "suspend", side_effect=_noop_suspend) as suspend_mock, \
+             patch("tuistore.app.subprocess.run") as run_mock, \
+             patch("tuistore.app.run_stream", side_effect=fake_stream) as stream_mock:
+            async with app.run_test() as pilot:
+                app.push_screen(modal)
+                await pilot.pause()
+                modal.action_run()
+                await pilot.pause()
+                await pilot.pause()
+                await pilot.pause()
+
+                logtext = modal.query_one("#logtext")
+                self.assertIn("compiling...", logtext.content.plain)
+
+        suspend_mock.assert_not_called()
+        run_mock.assert_not_called()
+        stream_mock.assert_called_once_with("cargo install haal")
+        self.assertFalse(modal.running)
+        self.assertTrue(modal.done)
 
 
 if __name__ == "__main__":

--- a/tests/test_interactive_command.py
+++ b/tests/test_interactive_command.py
@@ -1,0 +1,139 @@
+import unittest
+
+from tuistore.installer import is_interactive_command
+
+
+class SudoDetectionTest(unittest.TestCase):
+    """Every distro package-manager template tuistore ships already prefixes
+    the command with a literal `sudo` (see installed.py's `_UNINSTALL` /
+    `_UPDATE` dicts) -- catching that token is what covers pacman, apt, dnf,
+    zypper, emerge, eopkg, etc. all at once (github.com/Gheat1/tuistore/
+    issues/31)."""
+
+    def test_sudo_pacman_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo pacman -S ripgrep"))
+
+    def test_sudo_apt_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo apt install ripgrep"))
+
+    def test_sudo_dnf_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo dnf install ripgrep"))
+
+    def test_sudo_zypper_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo zypper install ripgrep"))
+
+    def test_sudo_emerge_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo emerge ripgrep"))
+
+    def test_sudo_eopkg_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo eopkg install ripgrep"))
+
+    def test_sudo_xbps_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo xbps-install ripgrep"))
+
+    def test_sudo_apk_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo apk add ripgrep"))
+
+    def test_sudo_yum_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo yum install ripgrep"))
+
+    def test_sudo_with_flags_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo -E apt install ripgrep"))
+
+    def test_sudo_mid_chain_is_interactive(self):
+        self.assertTrue(is_interactive_command("brew update && sudo apt install ripgrep"))
+
+    def test_sudo_as_substring_of_another_word_is_not_flagged(self):
+        # "sudo" must be its own token -- a package/flag that merely
+        # contains the substring must not trip the detector.
+        self.assertFalse(is_interactive_command("cargo install sudoku-solver"))
+        self.assertFalse(is_interactive_command("npm install -g pseudo-tool"))
+
+
+class YayParuDetectionTest(unittest.TestCase):
+    """AUR helpers are deliberately never run with sudo (pacman is; yay/paru
+    are not), so they need their own leading-verb check independent of the
+    sudo one -- and they prompt for their own confirmations (cleanbuild,
+    PKGBUILD review, etc.) regardless of sudo."""
+
+    def test_bare_yay_install_is_interactive(self):
+        self.assertTrue(is_interactive_command("yay -S ripgrep-all"))
+
+    def test_bare_paru_install_is_interactive(self):
+        self.assertTrue(is_interactive_command("paru -S ripgrep-all"))
+
+    def test_yay_uninstall_is_interactive(self):
+        self.assertTrue(is_interactive_command("yay -R ripgrep-all"))
+
+    def test_yay_behind_sudo_dash_e_is_interactive(self):
+        self.assertTrue(is_interactive_command("sudo -E yay -S ripgrep-all"))
+
+    def test_yay_behind_env_var_assignment_is_interactive(self):
+        self.assertTrue(is_interactive_command("env FOO=bar yay -S ripgrep-all"))
+
+    def test_yay_behind_bare_var_assignment_is_interactive(self):
+        self.assertTrue(is_interactive_command("FOO=bar yay -S ripgrep-all"))
+
+    def test_yay_behind_arch_wrapper_is_interactive(self):
+        self.assertTrue(is_interactive_command("arch -arm64 yay -S ripgrep-all"))
+
+    def test_yay_after_chained_command_is_interactive(self):
+        self.assertTrue(is_interactive_command("brew update && yay -S ripgrep-all"))
+
+    def test_yay_as_a_later_statement_in_a_multi_tool_script_is_interactive(self):
+        # shape of the "update all" action: several `echo "== name =="; cmd;
+        # echo` lines joined with newlines. The yay entry isn't the first
+        # statement, and none of the other entries need sudo -- this must
+        # still be caught, or a machine with only AUR-installed tools would
+        # never get the terminal handoff at all.
+        script = (
+            'echo "== foo =="; cargo install foo --force; echo\n'
+            'echo "== bar =="; yay -S bar; echo'
+        )
+        self.assertTrue(is_interactive_command(script))
+
+    def test_yay_as_substring_of_package_name_is_not_flagged(self):
+        self.assertFalse(is_interactive_command("cargo install yay-cli"))
+        self.assertFalse(is_interactive_command("npm install -g yay"))
+
+    def test_paru_as_substring_of_package_name_is_not_flagged(self):
+        self.assertFalse(is_interactive_command("cargo install paru-helper"))
+
+
+class NonInteractiveCommandTest(unittest.TestCase):
+    """The common case -- cargo/npm/uv/brew/pipx/go rarely prompt -- must
+    keep using the normal streamed-log UI, not the terminal handoff."""
+
+    def test_cargo_install_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("cargo install ripgrep"))
+
+    def test_cargo_install_force_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("cargo install ripgrep --force"))
+
+    def test_npm_install_global_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("npm install -g typescript"))
+
+    def test_uv_tool_install_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("uv tool install ruff"))
+
+    def test_uv_tool_upgrade_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("uv tool upgrade ruff"))
+
+    def test_brew_install_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("brew install ripgrep"))
+
+    def test_pipx_install_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("pipx install black"))
+
+    def test_go_install_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("go install github.com/x/y@latest"))
+
+    def test_gem_install_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("gem install bundler"))
+
+    def test_bare_clone_is_not_interactive(self):
+        self.assertFalse(is_interactive_command("git clone https://github.com/a/b && cd b"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_modal.py
+++ b/tests/test_run_modal.py
@@ -1,0 +1,126 @@
+import unittest
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+from ricekit import KitApp
+
+from tuistore.app import RunModal
+from tuistore.platform import Env
+
+
+@contextmanager
+def _noop_suspend():
+    """Stand-in for `App.suspend()` -- real suspension takes over the actual
+    terminal, which Textual's headless `run_test()` harness can't exercise
+    in CI, so tests patch it out with a context manager that does nothing."""
+    yield
+
+
+class Harness(KitApp):
+    def __init__(self) -> None:
+        super().__init__()
+        self.env = Env("linux", "arch", {"arch"}, tools={"pacman"})
+
+
+class RunModalTerminalHandoffTest(unittest.IsolatedAsyncioTestCase):
+    """RunModal drives uninstall/update/update-all/self-update -- the same
+    piped-stdout-with-no-stdin problem that hits InstallModal
+    (github.com/Gheat1/tuistore/issues/31) hits these too, e.g. `sudo
+    pacman -R {pkg}` for an uninstall or `yay -S {pkg}` for an update. A
+    command flagged by `is_interactive_command` must hand the real terminal
+    over via `App.suspend()` with fully inherited stdio instead of going
+    through the normal streamed `run_stream` path, and vice versa."""
+
+    async def test_sudo_uninstall_suspends_and_runs_with_inherited_stdio(self) -> None:
+        modal = RunModal("uninstall haal", "sudo pacman -R haal", danger=True, verb="uninstall")
+        app = Harness()
+        app.notify = Mock()
+        fake_proc = Mock(returncode=1)
+
+        with patch.object(app, "suspend", side_effect=_noop_suspend) as suspend_mock, \
+             patch("tuistore.app.subprocess.run", return_value=fake_proc) as run_mock, \
+             patch("tuistore.app.run_stream") as stream_mock:
+            async with app.run_test() as pilot:
+                app.push_screen(modal)
+                await pilot.pause()
+                modal.action_run()
+                await pilot.pause()
+                await pilot.pause()
+                await pilot.pause()
+
+        suspend_mock.assert_called_once()
+        run_mock.assert_called_once()
+        stream_mock.assert_not_called()
+        _, kwargs = run_mock.call_args
+        self.assertNotIn("stdout", kwargs)
+        self.assertNotIn("stderr", kwargs)
+        self.assertNotIn("stdin", kwargs)
+        argv = run_mock.call_args.args[0]
+        self.assertIn("sudo pacman -R haal", argv[-1])
+        self.assertFalse(modal.running)
+        self.assertTrue(modal.done)
+
+    async def test_multi_tool_update_all_script_with_later_yay_entry_suspends(self) -> None:
+        # shape of action_update_all's joined script: several
+        # `echo "== name =="; cmd; echo` lines, none of which need sudo, but
+        # one of which is a yay update -- must still trigger the handoff
+        # even though yay isn't the first statement.
+        script = (
+            'echo "== cargo-tool ==" ; cargo install cargo-tool --force ; echo\n'
+            'echo "== aur-tool ==" ; yay -S aur-tool ; echo'
+        )
+        modal = RunModal("update tuistore-installed", script, verb="update all")
+        app = Harness()
+        app.notify = Mock()
+        fake_proc = Mock(returncode=0)
+
+        with patch.object(app, "suspend", side_effect=_noop_suspend) as suspend_mock, \
+             patch("tuistore.app.subprocess.run", return_value=fake_proc) as run_mock, \
+             patch("tuistore.app.run_stream") as stream_mock:
+            async with app.run_test() as pilot:
+                app.push_screen(modal)
+                await pilot.pause()
+                modal.action_run()
+                await pilot.pause()
+                await pilot.pause()
+                await pilot.pause()
+
+        suspend_mock.assert_called_once()
+        run_mock.assert_called_once()
+        stream_mock.assert_not_called()
+
+    async def test_non_interactive_update_streams_and_never_suspends(self) -> None:
+        modal = RunModal("update haal", "cargo install haal --force", verb="update")
+        app = Harness()
+        app.notify = Mock()
+        on_success = Mock()
+        modal.on_success = on_success
+
+        async def fake_stream(command):
+            yield ("out", "updating...")
+            yield ("exit", "0")
+
+        with patch.object(app, "suspend", side_effect=_noop_suspend) as suspend_mock, \
+             patch("tuistore.app.subprocess.run") as run_mock, \
+             patch("tuistore.app.run_stream", side_effect=fake_stream) as stream_mock:
+            async with app.run_test() as pilot:
+                app.push_screen(modal)
+                await pilot.pause()
+                modal.action_run()
+                await pilot.pause()
+                await pilot.pause()
+                await pilot.pause()
+
+                logtext = modal.query_one("#rlogtext")
+                self.assertIn("updating...", logtext.content.plain)
+
+        suspend_mock.assert_not_called()
+        run_mock.assert_not_called()
+        stream_mock.assert_called_once_with("cargo install haal --force")
+        self.assertFalse(modal.running)
+        self.assertTrue(modal.done)
+        on_success.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tuistore/app.py
+++ b/tuistore/app.py
@@ -8,8 +8,10 @@ doctrine — rounded borders, focus-recolor, role-based color, one animation.
 
 from __future__ import annotations
 
+import subprocess
 import webbrowser
 from datetime import datetime, timezone
+from typing import Callable
 
 from rich.text import Text
 from textual import on, work
@@ -27,8 +29,9 @@ from ricekit.widgets import KitFooter, KitScroll, NavList, Splitter, pop_in
 
 from . import __version__, github, installed as inst, platform
 from .catalog import Catalog, Entry, load, refetch, search
-from .installer import KINDS, Method, best, rank, run_stream
+from .installer import KINDS, Method, best, is_interactive_command, rank, run_stream
 from .paths import StoreDirs
+from .shell import shell_command, shell_env, wrap_command
 
 DIRS = StoreDirs()
 
@@ -79,6 +82,37 @@ def rel_time(iso: str | None) -> str:
 FEATURED_CAT = "★ Featured"
 INSTALLED_CAT = "◆ Installed"
 ALL_CAT = "All tools"
+
+
+# ── run a command, handing the terminal over when it needs one ──────────────
+async def run_maybe_interactive(app, command: str,
+                                 on_line: Callable[[str], None] | None = None) -> tuple[str, bool]:
+    """Run `command`, returning `(exit_code, interactive)`.
+
+    tuistore's normal install/update/uninstall UI (`installer.run_stream`)
+    pipes the child's stdout but never wires up its stdin, so a command that
+    prompts on the terminal — a sudo password, an AUR helper's y/N
+    confirmations — can never receive it (github.com/Gheat1/tuistore/
+    issues/31). `installer.is_interactive_command` flags those commands;
+    for them we give up the TUI's own terminal control via `App.suspend()`
+    and run with fully inherited stdio (no captured output at all), so the
+    real terminal behaves exactly as it would outside tuistore. Everything
+    else keeps streaming through `run_stream` exactly as before, calling
+    `on_line` for each output line.
+    """
+    if is_interactive_command(command):
+        shell, shell_args = shell_command()
+        with app.suspend():
+            proc = subprocess.run([shell, *shell_args, wrap_command(command)], env=shell_env())
+        return str(proc.returncode), True
+    code = "?"
+    async for kind, payload in run_stream(command):
+        if kind == "out":
+            if on_line is not None:
+                on_line(payload)
+        else:
+            code = payload
+    return code, False
 
 
 # ── install modal ────────────────────────────────────────────────────────────
@@ -272,7 +306,6 @@ class InstallModal(ModalScreen):
     async def _install(self) -> None:
         logw = self.query_one("#logtext", Static)
         lines: list[str] = []
-        code = "?"
 
         def flush() -> None:
             body = Text()
@@ -282,13 +315,12 @@ class InstallModal(ModalScreen):
             log = self.query_one("#log")
             log.scroll_end(animate=False)
 
-        async for kind, payload in run_stream(self._cmd()):
-            if kind == "out":
-                lines.append(payload)
-                if len(lines) % 2 == 0 or len(lines) < 12:
-                    flush()
-            else:
-                code = payload
+        def on_line(payload: str) -> None:
+            lines.append(payload)
+            if len(lines) % 2 == 0 or len(lines) < 12:
+                flush()
+
+        code, _interactive = await run_maybe_interactive(self.app, self._cmd(), on_line)
         flush()
 
         self.running = False
@@ -598,7 +630,6 @@ class RunModal(ModalScreen):
     async def _go(self) -> None:
         logw = self.query_one("#rlogtext", Static)
         lines: list[str] = []
-        code = "?"
 
         def flush() -> None:
             body = Text()
@@ -607,13 +638,12 @@ class RunModal(ModalScreen):
             logw.update(body)
             self.query_one("#rlog").scroll_end(animate=False)
 
-        async for kind, payload in run_stream(self.command):
-            if kind == "out":
-                lines.append(payload)
-                if len(lines) % 2 == 0 or len(lines) < 12:
-                    flush()
-            else:
-                code = payload
+        def on_line(payload: str) -> None:
+            lines.append(payload)
+            if len(lines) % 2 == 0 or len(lines) < 12:
+                flush()
+
+        code, _interactive = await run_maybe_interactive(self.app, self.command, on_line)
         self.running = False
         self.done = True
         p = palette

--- a/tuistore/installer.py
+++ b/tuistore/installer.py
@@ -363,6 +363,57 @@ def best(methods: Iterable[Method], env: Env) -> Method | None:
     return ranked[0] if ranked else None
 
 
+# ── does a command need real terminal access? ───────────────────────────────
+# `run_stream` below pipes a command's stdout but never wires up its stdin —
+# a child that prompts on its controlling terminal (a sudo password, an AUR
+# helper's y/N confirmations) can never receive input while tuistore is
+# streaming it that way, which is exactly the cause of
+# github.com/Gheat1/tuistore/issues/31. `is_interactive_command` flags those
+# cases so callers can hand the real terminal over instead (see app.py's use
+# of `App.suspend()`) rather than using the piped-streaming UI at all.
+_SUDO_TOKEN = re.compile(r"(?<![\w-])sudo(?![\w-])")
+_STATEMENT_SEP = re.compile(r"&&|\|\||[;\n]")
+_AUR_VERB = re.compile(r"\b(?:yay|paru)\b")
+
+
+def is_interactive_command(command: str) -> bool:
+    """Best-guess: will `command` want to read from the real terminal?
+
+    Conservative on purpose — flagging a command that never needed a real
+    terminal is a worse UX regression (loses the streamed log for nothing)
+    than missing one that did (reproduces the original hang/garbled-input
+    bug). Only two catalog-realistic cases are caught:
+
+      * `sudo` anywhere in the command, as its own token — every distro
+        package-manager template here and in `installed.py`'s
+        `_UNINSTALL`/`_UPDATE` dicts already ships with a literal `sudo `
+        prefix, so this alone covers pacman/apt/dnf/yum/zypper/xbps/apk/
+        emerge/eopkg.
+      * `yay` or `paru` as a statement's leading verb, skipping the same
+        sudo/env/arch wrapper prefixes `_CMD_PREFIX` skips for
+        `classify(..., at_start=True)` above — reused directly here rather
+        than going through `classify`, since `classify`'s yay/paru patterns
+        are anchored on the *install* flag (`-S`) and would miss the
+        `_UNINSTALL`/`_UPDATE` dicts' `yay -R {pkg}` / `paru -R {pkg}`
+        templates. AUR helpers are deliberately never run with sudo, so
+        they need their own check independent of the one above — they
+        prompt for their own confirmations (cleanbuild, PKGBUILD review,
+        etc.) regardless of sudo or which flag is used.
+
+    Checked per top-level statement (split on `&&`, `||`, `;`, newlines) so
+    a multi-command script — e.g. the TUI's "update all" action, which joins
+    several `echo "== name =="; cmd; echo` lines — is still caught even when
+    the interactive command isn't the very first statement.
+    """
+    if _SUDO_TOKEN.search(command):
+        return True
+    for stmt in _STATEMENT_SEP.split(command):
+        m = _AUR_VERB.search(stmt)
+        if m and _CMD_PREFIX.fullmatch(stmt[: m.start()]):
+            return True
+    return False
+
+
 # ── run an install, streaming output ───────────────────────────────────────
 async def run_stream(command: str) -> AsyncIterator[tuple[str, str]]:
     """Execute `command` in a login shell, yielding ("out", line) as it runs


### PR DESCRIPTION
## Root cause

`run_stream()` pipes a child process's stdout but never wires up its stdin, so any command that prompts on the controlling terminal — a `sudo` password, `yay`/`paru`'s y/N confirmations — has no path to receive keystrokes while tuistore's TUI holds the raw terminal. That's the actual bug behind #31: passwords appear to register extra/garbled keystrokes, and AUR-helper prompts just hang until they time out.

## Fix

- `installer.is_interactive_command()` — a conservative heuristic that flags a command needing real terminal access: `sudo` anywhere as its own token (covers every distro package-manager template already prefixed with it — pacman/apt/dnf/zypper/yum/xbps/apk/emerge/eopkg), or `yay`/`paru` as a statement's leading verb (checked independently since AUR helpers are deliberately never run with sudo, and checked per-statement so an `update all` script catches a `yay` entry even when it isn't the first command).
- `app.run_maybe_interactive()` — shared by `InstallModal._install()` and `RunModal._go()` (previously near-identical duplicated loops). For a flagged command, it gives up the TUI's terminal via `App.suspend()` and runs with fully inherited stdio (`subprocess.run`, no pipes at all) so the real terminal behaves exactly as it would outside tuistore. Everything else keeps streaming through the existing `run_stream()` path unchanged.

## Supersedes #33

That PR's one-line diff added `is_interactive_command` to an import from `.shell`, but that name never existed anywhere in the codebase — an `ImportError` that broke every CI job. There was nothing to build on, so this is a fresh implementation of the same idea, done properly.

## Testing

- New: `tests/test_interactive_command.py` (26 cases — sudo across every distro package manager, yay/paru with sudo/env/arch wrapper prefixes, multi-statement scripts, false-positive guards for substrings like `sudoku-solver`), plus modal-level tests in `tests/test_install_modal.py` and the new `tests/test_run_modal.py` that mock `App.suspend`/`subprocess.run` to verify the real terminal handoff happens for interactive commands and never happens for plain ones.
- Full suite: 192 tests pass on 3.11, 3.12, and 3.13, no regressions.

Closes #31.