### PR TITLE
Only hand http/https URLs to the system browser

### DIFF
--- a/tests/test_browse_url.py
+++ b/tests/test_browse_url.py
@@ -1,0 +1,66 @@
+import unittest
+
+from tuistore.catalog import Entry, load
+
+REPO_URL = "https://github.com/a/b"
+
+
+def make_entry(homepage: str | None) -> Entry:
+    return Entry(name="x", url=REPO_URL, homepage=homepage)
+
+
+class BrowseUrlTest(unittest.TestCase):
+    def test_https_homepage_passes_through(self) -> None:
+        self.assertEqual(
+            make_entry("https://example.org").browse_url, "https://example.org"
+        )
+
+    def test_http_homepage_passes_through(self) -> None:
+        self.assertEqual(
+            make_entry("http://example.org").browse_url, "http://example.org"
+        )
+
+    def test_non_http_scheme_falls_back_to_repo_url(self) -> None:
+        # ssh:// is a real value in the shipped catalog; the rest are the
+        # classes of scheme xdg-open would happily dispatch to a non-browser
+        # handler if we handed them straight to webbrowser.open().
+        hostile_homepages = [
+            "ssh://slides.tseivan.com",
+            "javascript:alert(1)",
+            "file:///etc/passwd",
+            "data:text/html,x",
+            "vscode://x",
+        ]
+        for homepage in hostile_homepages:
+            with self.subTest(homepage=homepage):
+                self.assertEqual(make_entry(homepage).browse_url, REPO_URL)
+
+    def test_schemeless_homepage_is_upgraded_to_https(self) -> None:
+        self.assertEqual(make_entry("urwid.org").browse_url, "https://urwid.org")
+        self.assertEqual(
+            make_entry("www.coderholic.com/pyradio").browse_url,
+            "https://www.coderholic.com/pyradio",
+        )
+
+    def test_missing_or_blank_homepage_falls_back_to_repo_url(self) -> None:
+        for homepage in (None, "", "   "):
+            with self.subTest(homepage=homepage):
+                self.assertEqual(make_entry(homepage).browse_url, REPO_URL)
+
+    def test_case_insensitive_scheme_check(self) -> None:
+        self.assertEqual(
+            make_entry("HTTPS://Example.org").browse_url, "HTTPS://Example.org"
+        )
+
+    def test_shipped_catalog_yields_only_http_browse_urls(self) -> None:
+        # Regression net: a future catalog refresh that introduces a new
+        # hostile scheme must fail here, not surface at "press o" time.
+        for entry in load().entries:
+            with self.subTest(entry=entry.name):
+                self.assertTrue(
+                    entry.browse_url.lower().startswith(("http://", "https://"))
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tuistore/app.py
+++ b/tuistore/app.py
@@ -521,7 +521,7 @@ class ReadmeModal(ModalScreen):
             Text("j/k scroll · o open in browser · esc close", style=p.dim))
 
     def action_browser(self) -> None:
-        webbrowser.open(self.entry.homepage or self.entry.url)
+        webbrowser.open(self.entry.browse_url)
         self.app.notify(f"opened {self.entry.url}")
 
     def action_close(self) -> None:
@@ -1670,7 +1670,7 @@ class StoreApp(KitApp):
     def action_open_browser(self) -> None:
         if not self.current:
             return
-        url = self.current.homepage or self.current.url
+        url = self.current.browse_url
         webbrowser.open(url)
         self.notify(f"opened {url}")
 

--- a/tuistore/catalog.py
+++ b/tuistore/catalog.py
@@ -47,6 +47,25 @@ class Entry:
     def is_github(self) -> bool:
         return parse_repo(self.url) is not None
 
+    @property
+    def browse_url(self) -> str:
+        """A URL that is safe to hand to the system browser.
+
+        `homepage` comes verbatim from the repo owner's GitHub `homepageUrl`,
+        so it can carry any scheme — and `webbrowser.open()` dispatches a
+        non-http scheme to whatever desktop handler is registered for it
+        (the shipped catalog already contains an `ssh://` homepage). Only
+        http/https pass through; a schemeless value is treated as a bare
+        domain and upgraded to https; anything else falls back to the repo
+        URL, which is always a well-formed https GitHub link.
+        """
+        homepage = (self.homepage or "").strip()
+        if not homepage:
+            return self.url
+        if ":" not in homepage:
+            homepage = f"https://{homepage}"
+        return homepage if homepage.lower().startswith(("http://", "https://")) else self.url
+
     # ── (de)serialize ──────────────────────────────────────────────────
     def to_dict(self) -> dict:
         d = {"name": self.name, "url": self.url, "description": self.description,


### PR DESCRIPTION
**TL;DR** — pressing `o` calls `webbrowser.open()` on a catalog entry's `homepage`, which is copied verbatim from the repo owner's GitHub `homepageUrl`. No scheme check. The shipped catalog already contains `ssh://slides.tseivan.com`. This adds `Entry.browse_url` as the one choke point between catalog data and the browser.

### Before / after

| `homepage` | Before | After |
|---|---|---|
| `https://example.org` | opens it | opens it *(unchanged)* |
| `ssh://slides.tseivan.com` | handed to `xdg-open` | falls back to the repo URL |
| `javascript:` / `file://` / `data:` / `vscode://` | handed to `xdg-open` | falls back to the repo URL |
| `urwid.org` *(schemeless)* | `webbrowser.open()` can't use it | upgraded to `https://urwid.org` |
| missing / blank | falls back to repo URL | falls back to repo URL *(unchanged)* |

### Why it matters

`webbrowser.open()` on Linux falls through to `xdg-open`, which dispatches on scheme to whatever desktop handler is registered. A non-http scheme is therefore a one-keypress invocation of an arbitrary desktop handler, not a page view — and the field is controlled by the owner of any of the ~800 catalog repos.

Not hypothetical: three shipped entries already have non-http or schemeless homepages.

### The change — 3 files, +87/−2

- **`catalog.py`** — new `Entry.browse_url` property, next to the existing `slug` / `repo` / `is_github` derived properties. http/https pass through; a schemeless value is treated as a bare domain and upgraded to https; **anything else falls back to the repo URL**, which is always a well-formed `https://github.com/…` string. Fail-closed: an unrecognized shape falls back rather than passing through.
- **`app.py`** — both `webbrowser.open()` call sites (`ReadmeModal.action_browser`, `StoreApp.action_open_browser`) route through it. Two lines.
- **`tests/test_browse_url.py`** — new, 7 cases.

### Deliberately not changed

- **`tools/build_catalog.py` and `catalog.json`.** Validating at generation time doesn't protect users who already have a catalog, and the user catalog is refetched from the network at runtime. The check belongs at the point of use. The three odd homepages in the data are left alone — `catalog.json` is generated and never hand-edited.
- **`__main__.py:290`**, where `tuistore info` *prints* `entry.homepage or entry.url`. Printing a URL is not opening it.

### Catalog impact: 3 entries, all benign

| Entry | `homepage` | now opens |
|---|---|---|
| `urwid` | `urwid.org` | `https://urwid.org` |
| `pyradio` | `www.coderholic.com/pyradio` | `https://www.coderholic.com/pyradio` |
| `ssh-slides` | `ssh://slides.tseivan.com` | `https://github.com/ivantsepp/ssh-slides` |

The first two didn't open usefully before anyway.

### Tests

199 passing; no existing test modified or deleted. New file covers http/https pass-through, the five hostile scheme classes, the schemeless upgrade, missing/blank fallback, and an uppercase `HTTPS://` scheme (the check lowercases first, so it isn't mistakenly rejected).

The last test walks the **real shipped catalog** and asserts every entry's `browse_url` is http/https — the regression net, so a future catalog refresh that introduces a new hostile scheme fails in CI rather than at "press `o`" time.
